### PR TITLE
Add OpenAI realtime API support

### DIFF
--- a/Sources/OpenAI/OpenAI+Realtime.swift
+++ b/Sources/OpenAI/OpenAI+Realtime.swift
@@ -30,7 +30,7 @@ public extension OpenAI {
         }
     }
 
-    struct RealtimeSessionCreateResponse: Codable {
+    public struct RealtimeSessionCreateResponse: Codable {
         public struct ClientSecret: Codable {
             public let value: String
             public let expires_at: Int
@@ -79,7 +79,7 @@ public extension OpenAI {
         }
     }
 
-    struct RealtimeTranscriptionSessionCreateResponse: Codable {
+    public struct RealtimeTranscriptionSessionCreateResponse: Codable {
         public struct ClientSecret: Codable {
             public let value: String
             public let expires_at: Int
@@ -93,11 +93,15 @@ public extension OpenAI {
     }
 
     /// Returns a configured WebSocket task for communicating with the realtime API.
-    func realtimeWebSocketTask(clientSecret: String) -> URLSessionWebSocketTask {
-        var components = URLComponents(url: configuration.baseURL, resolvingAgainstBaseURL: false)!
+    public func realtimeWebSocketTask(clientSecret: String) throws -> URLSessionWebSocketTask {
+        guard var components = URLComponents(url: configuration.baseURL, resolvingAgainstBaseURL: false) else {
+            throw LangToolError.invalidURL
+        }
         components.scheme = components.scheme == "http" ? "ws" : "wss"
         components.path = "/v1/realtime"
-        let url = components.url!
+        guard let url = components.url else {
+            throw LangToolError.invalidURL
+        }
         var request = URLRequest(url: url)
         request.addValue("Bearer \(clientSecret)", forHTTPHeaderField: "Authorization")
         return session.webSocketTask(with: request)

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -13,7 +13,7 @@ final public class OpenAI: LangTools {
     public typealias Model = OpenAIModel
     public typealias ErrorResponse = OpenAIErrorResponse
 
-    fileprivate var configuration: OpenAIConfiguration
+    var configuration: OpenAIConfiguration
     fileprivate var apiKey: String { configuration.apiKey }
     public var session: URLSession { configuration.session }
 

--- a/Sources/OpenAI/README.md
+++ b/Sources/OpenAI/README.md
@@ -184,7 +184,11 @@ let session = try await openai.perform(request:
     OpenAI.RealtimeSessionCreateRequest(model: .gpt4o_realtimePreview)
 )
 
-let socket = openai.realtimeWebSocketTask(clientSecret: session.client_secret!.value)
+guard let clientSecret = session.client_secret?.value else {
+    // Handle error: client_secret is nil
+    return
+}
+let socket = try openai.realtimeWebSocketTask(clientSecret: clientSecret)
 socket.resume()
 ```
 


### PR DESCRIPTION
## Summary
- expose configuration and apiKey to extensions
- register realtime session requests in validator list
- implement `OpenAI+Realtime` with session request structs and WebSocket helper
- document realtime WebSocket API usage

## Testing
- `swift test` *(fails: URLSession unavailable: FoundationNetworking missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68412232023c8327a493d52f0210f70f)