### PR TITLE
Add OpenAI Responses API support

### DIFF
--- a/Sources/OpenAI/OpenAI+ChatCompletionRequest.swift
+++ b/Sources/OpenAI/OpenAI+ChatCompletionRequest.swift
@@ -310,13 +310,7 @@ extension OpenAI {
 
                 /// Sanitises a candidate `name` to match OpenAI's `^[a-zA-Z0-9_-]{1,64}$`.
                 public static func sanitize(name: String) -> String {
-                    let cleaned = name
-                        .unicodeScalars
-                        .map { CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_-")).contains($0) ? Character($0) : "_" }
-                        .map(String.init)
-                        .joined()
-                    let truncated = String(cleaned.prefix(64))
-                    return truncated.isEmpty ? "structured_response" : truncated
+                    OpenAI.sanitizeSchemaName(name)
                 }
             }
 

--- a/Sources/OpenAI/OpenAI+Response.swift
+++ b/Sources/OpenAI/OpenAI+Response.swift
@@ -250,7 +250,9 @@ extension OpenAI {
             delta = try? container.decode(String.self, forKey: .delta)
             item_id = try? container.decode(String.self, forKey: .item_id)
             item = try? container.decode(ResponseResponse.OutputItem.self, forKey: .item)
-            response = try? container.decode(ResponseResponse.self, forKey: .response)
+            // decodeIfPresent (not try?) so a malformed terminal `response` payload surfaces
+            // as a stream error rather than silently dropping status/usage/id.
+            response = try container.decodeIfPresent(ResponseResponse.self, forKey: .response)
         }
 
         /// Maps this event onto a partial response that can be combined into the running result.

--- a/Sources/OpenAI/OpenAI+Response.swift
+++ b/Sources/OpenAI/OpenAI+Response.swift
@@ -95,7 +95,7 @@ public extension OpenAI {
                     text += item.outputText
                 case "function_call":
                     calls.append(ToolSelection(
-                        index: 0,
+                        index: calls.count,
                         id: item.call_id ?? item.id ?? "",
                         type: .function,
                         function: .init(name: item.name ?? "", arguments: item.arguments ?? "")))
@@ -103,7 +103,7 @@ public extension OpenAI {
                     break
                 }
             }
-            if output.isEmpty && text.isEmpty && calls.isEmpty { return nil }
+            if text.isEmpty && calls.isEmpty { return nil }
             let content: Content = text.isEmpty ? .null : .string(text)
             return Item(role: .assistant, content: content, tool_calls: calls.isEmpty ? nil : calls)
         }
@@ -247,10 +247,10 @@ extension OpenAI {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             type = try container.decode(String.self, forKey: .type)
             // `delta` is a string for text/argument deltas; ignore non-string deltas.
-            delta = (try? container.decodeIfPresent(String.self, forKey: .delta)) ?? nil
-            item_id = (try? container.decodeIfPresent(String.self, forKey: .item_id)) ?? nil
-            item = (try? container.decodeIfPresent(ResponseResponse.OutputItem.self, forKey: .item)) ?? nil
-            response = (try? container.decodeIfPresent(ResponseResponse.self, forKey: .response)) ?? nil
+            delta = try? container.decode(String.self, forKey: .delta)
+            item_id = try? container.decode(String.self, forKey: .item_id)
+            item = try? container.decode(ResponseResponse.OutputItem.self, forKey: .item)
+            response = try? container.decode(ResponseResponse.self, forKey: .response)
         }
 
         /// Maps this event onto a partial response that can be combined into the running result.

--- a/Sources/OpenAI/OpenAI+Response.swift
+++ b/Sources/OpenAI/OpenAI+Response.swift
@@ -33,7 +33,6 @@ public extension OpenAI {
         public let incomplete_details: IncompleteDetails?
 
         /// The per-chunk delta, populated only while streaming. Excluded from Codable.
-        @CodableIgnored
         public var streamingDelta: Delta?
 
         public init(id: String? = nil, object: String? = nil, created_at: Int? = nil, model: String? = nil, status: String? = nil, output: [OutputItem] = [], usage: Usage? = nil, error: ResponseError? = nil, incomplete_details: IncompleteDetails? = nil, delta: Delta? = nil) {
@@ -48,6 +47,44 @@ public extension OpenAI {
             self.incomplete_details = incomplete_details
             self.streamingDelta = delta
         }
+
+        // MARK: - Codable
+
+        // A custom implementation (rather than synthesised) is required so that `output`
+        // tolerates being absent: terminal events such as `response.failed` / `response.incomplete`
+        // can omit it, and a synthesised decoder would throw `keyNotFound` (default property
+        // values are not applied by synthesised `Decodable`), masking the real error/status.
+        enum CodingKeys: String, CodingKey {
+            case id, object, created_at, model, status, output, usage, error, incomplete_details
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decodeIfPresent(String.self, forKey: .id)
+            object = try container.decodeIfPresent(String.self, forKey: .object)
+            created_at = try container.decodeIfPresent(Int.self, forKey: .created_at)
+            model = try container.decodeIfPresent(String.self, forKey: .model)
+            status = try container.decodeIfPresent(String.self, forKey: .status)
+            output = try container.decodeIfPresent([OutputItem].self, forKey: .output) ?? []
+            usage = try container.decodeIfPresent(Usage.self, forKey: .usage)
+            error = try container.decodeIfPresent(ResponseError.self, forKey: .error)
+            incomplete_details = try container.decodeIfPresent(IncompleteDetails.self, forKey: .incomplete_details)
+            streamingDelta = nil
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(id, forKey: .id)
+            try container.encodeIfPresent(object, forKey: .object)
+            try container.encodeIfPresent(created_at, forKey: .created_at)
+            try container.encodeIfPresent(model, forKey: .model)
+            try container.encodeIfPresent(status, forKey: .status)
+            try container.encode(output, forKey: .output)
+            try container.encodeIfPresent(usage, forKey: .usage)
+            try container.encodeIfPresent(error, forKey: .error)
+            try container.encodeIfPresent(incomplete_details, forKey: .incomplete_details)
+        }
+
 
         // MARK: - LangToolsStreamableResponse
 

--- a/Sources/OpenAI/OpenAI+Response.swift
+++ b/Sources/OpenAI/OpenAI+Response.swift
@@ -321,7 +321,9 @@ extension OpenAI {
                 guard let item, item.type == "function_call" else { return nil }
                 return ResponseResponse(output: [item])
             case "response.function_call_arguments.delta":
-                guard let delta else { return nil }
+                // Require item_id: without it the delta can't be merged into its call and
+                // would orphan into a duplicate function_call item, so drop it instead.
+                guard let delta, let item_id else { return nil }
                 return ResponseResponse(output: [.init(type: "function_call", id: item_id, arguments: delta)])
             case "response.completed", "response.incomplete", "response.failed":
                 guard let response else { return nil }

--- a/Sources/OpenAI/OpenAI+Response.swift
+++ b/Sources/OpenAI/OpenAI+Response.swift
@@ -1,0 +1,292 @@
+//
+//  OpenAI+Response.swift
+//  OpenAI
+//
+//  Responses API response object and streaming events.
+//
+
+import Foundation
+import LangTools
+
+
+public extension OpenAI {
+    /// The object returned by the Responses API (`POST /v1/responses`).
+    ///
+    /// The model's output is delivered as an array of ``OutputItem`` values (assistant
+    /// messages, function calls, reasoning, etc.) rather than chat-style `choices`. This
+    /// type bridges that shape onto the LangTools chat/tool-calling/streaming protocols so
+    /// the shared engine (tool-call loop, streaming accumulation, structured output) works.
+    struct ResponseResponse: Codable, LangToolsStreamableChatResponse, LangToolsToolCallingResponse, LangToolsStructuredOutputResponse {
+        public typealias Message = OpenAI.Item
+        public typealias Delta = OpenAI.Message.Delta
+        public typealias ToolSelection = OpenAI.Message.ToolCall
+
+        public let id: String?
+        public let object: String?
+        public let created_at: Int?
+        public let model: String?
+        /// `completed`, `in_progress`, `failed`, `incomplete`, etc.
+        public let status: String?
+        public var output: [OutputItem]
+        public let usage: Usage?
+        public let error: ResponseError?
+        public let incomplete_details: IncompleteDetails?
+
+        /// The per-chunk delta, populated only while streaming. Excluded from Codable.
+        @CodableIgnored
+        public var streamingDelta: Delta?
+
+        public init(id: String? = nil, object: String? = nil, created_at: Int? = nil, model: String? = nil, status: String? = nil, output: [OutputItem] = [], usage: Usage? = nil, error: ResponseError? = nil, incomplete_details: IncompleteDetails? = nil, delta: Delta? = nil) {
+            self.id = id
+            self.object = object
+            self.created_at = created_at
+            self.model = model
+            self.status = status
+            self.output = output
+            self.usage = usage
+            self.error = error
+            self.incomplete_details = incomplete_details
+            self.streamingDelta = delta
+        }
+
+        // MARK: - LangToolsStreamableResponse
+
+        public var delta: Delta? { streamingDelta }
+
+        public static var empty: ResponseResponse { ResponseResponse() }
+
+        public func combining(with next: ResponseResponse) -> ResponseResponse {
+            ResponseResponse(
+                id: next.id ?? id,
+                object: next.object ?? object,
+                created_at: next.created_at ?? created_at,
+                model: next.model ?? model,
+                status: next.status ?? status,
+                output: ResponseResponse.merge(output, with: next.output),
+                usage: next.usage ?? usage,
+                error: next.error ?? error,
+                incomplete_details: next.incomplete_details ?? incomplete_details,
+                delta: next.streamingDelta
+            )
+        }
+
+        static func merge(_ items: [OutputItem], with next: [OutputItem]) -> [OutputItem] {
+            var result = items
+            for item in next {
+                if let id = item.id, let index = result.firstIndex(where: { $0.id == id }) {
+                    result[index] = result[index].combining(with: item)
+                } else {
+                    result.append(item)
+                }
+            }
+            return result
+        }
+
+        // MARK: - LangToolsChatResponse
+
+        /// The assistant message synthesised from the output items (concatenated text and
+        /// any function calls), mirroring the role `ChatCompletionResponse.choice.message` plays.
+        public var message: Item? {
+            var text = ""
+            var calls: [ToolSelection] = []
+            for item in output {
+                switch item.type {
+                case "message":
+                    text += item.outputText
+                case "function_call":
+                    calls.append(ToolSelection(
+                        index: 0,
+                        id: item.call_id ?? item.id ?? "",
+                        type: .function,
+                        function: .init(name: item.name ?? "", arguments: item.arguments ?? "")))
+                default:
+                    break
+                }
+            }
+            if output.isEmpty && text.isEmpty && calls.isEmpty { return nil }
+            let content: Content = text.isEmpty ? .null : .string(text)
+            return Item(role: .assistant, content: content, tool_calls: calls.isEmpty ? nil : calls)
+        }
+
+        typealias Content = OpenAI.Message.Content
+
+        // MARK: - LangToolsStructuredOutputResponse
+
+        /// The full assistant text output, convenient for reading the final result.
+        public var outputText: String {
+            output.filter { $0.type == "message" }.map { $0.outputText }.joined()
+        }
+
+        public var jsonContent: String? {
+            let text = outputText
+            return text.isEmpty ? nil : text
+        }
+
+        // MARK: - Nested types
+
+        /// An item in the model's `output` array.
+        public struct OutputItem: Codable {
+            /// `message`, `function_call`, `reasoning`, `web_search_call`, etc.
+            public var type: String
+            public var id: String?
+            public var status: String?
+            // message
+            public var role: String?
+            public var content: [OutputContent]?
+            // function_call
+            public var call_id: String?
+            public var name: String?
+            public var arguments: String?
+
+            public init(type: String, id: String? = nil, status: String? = nil, role: String? = nil, content: [OutputContent]? = nil, call_id: String? = nil, name: String? = nil, arguments: String? = nil) {
+                self.type = type
+                self.id = id
+                self.status = status
+                self.role = role
+                self.content = content
+                self.call_id = call_id
+                self.name = name
+                self.arguments = arguments
+            }
+
+            /// Concatenated `output_text` content of this (message) item.
+            public var outputText: String {
+                content?.filter { $0.type == "output_text" }.compactMap { $0.text }.joined() ?? ""
+            }
+
+            func combining(with next: OutputItem) -> OutputItem {
+                let mergedArguments: String?
+                if arguments == nil && next.arguments == nil { mergedArguments = nil }
+                else { mergedArguments = (arguments ?? "") + (next.arguments ?? "") }
+                let mergedContent: [OutputContent]?
+                switch (content, next.content) {
+                case (let a?, let b?): mergedContent = a + b
+                case (let a?, nil): mergedContent = a
+                case (nil, let b?): mergedContent = b
+                case (nil, nil): mergedContent = nil
+                }
+                return OutputItem(
+                    type: type,
+                    id: id ?? next.id,
+                    status: next.status ?? status,
+                    role: role ?? next.role,
+                    content: mergedContent,
+                    call_id: call_id ?? next.call_id,
+                    name: name ?? next.name,
+                    arguments: mergedArguments)
+            }
+        }
+
+        public struct OutputContent: Codable {
+            /// `output_text` or `refusal`.
+            public var type: String
+            public var text: String?
+            public var refusal: String?
+
+            public init(type: String, text: String? = nil, refusal: String? = nil) {
+                self.type = type
+                self.text = text
+                self.refusal = refusal
+            }
+        }
+
+        public struct Usage: Codable {
+            public let input_tokens: Int
+            public let output_tokens: Int
+            public let total_tokens: Int
+            public let input_tokens_details: InputTokensDetails?
+            public let output_tokens_details: OutputTokensDetails?
+
+            public init(input_tokens: Int, output_tokens: Int, total_tokens: Int, input_tokens_details: InputTokensDetails? = nil, output_tokens_details: OutputTokensDetails? = nil) {
+                self.input_tokens = input_tokens
+                self.output_tokens = output_tokens
+                self.total_tokens = total_tokens
+                self.input_tokens_details = input_tokens_details
+                self.output_tokens_details = output_tokens_details
+            }
+
+            public struct InputTokensDetails: Codable {
+                public let cached_tokens: Int?
+            }
+
+            public struct OutputTokensDetails: Codable {
+                public let reasoning_tokens: Int?
+            }
+        }
+
+        public struct ResponseError: Codable {
+            public let code: String?
+            public let message: String?
+        }
+
+        public struct IncompleteDetails: Codable {
+            public let reason: String?
+        }
+    }
+}
+
+// MARK: - Streaming events
+
+extension OpenAI {
+    /// A single semantic streaming event from the Responses API SSE stream.
+    ///
+    /// Events are mapped into partial ``ResponseResponse`` values by ``partialResponse`` so
+    /// they can flow through the shared streaming engine (which accumulates them via
+    /// ``ResponseResponse/combining(with:)``). Events that carry no incremental payload
+    /// return `nil` and are skipped.
+    struct ResponseStreamEvent: Decodable {
+        let type: String
+        let delta: String?
+        let item_id: String?
+        let item: ResponseResponse.OutputItem?
+        let response: ResponseResponse?
+
+        enum CodingKeys: String, CodingKey { case type, delta, item_id, item, response }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            type = try container.decode(String.self, forKey: .type)
+            // `delta` is a string for text/argument deltas; ignore non-string deltas.
+            delta = (try? container.decodeIfPresent(String.self, forKey: .delta)) ?? nil
+            item_id = (try? container.decodeIfPresent(String.self, forKey: .item_id)) ?? nil
+            item = (try? container.decodeIfPresent(ResponseResponse.OutputItem.self, forKey: .item)) ?? nil
+            response = (try? container.decodeIfPresent(ResponseResponse.self, forKey: .response)) ?? nil
+        }
+
+        /// Maps this event onto a partial response that can be combined into the running result.
+        var partialResponse: ResponseResponse? {
+            switch type {
+            case "response.output_text.delta":
+                guard let delta else { return nil }
+                return ResponseResponse(
+                    output: [.init(type: "message", id: item_id, role: "assistant", content: [.init(type: "output_text", text: delta)])],
+                    delta: .init(role: .assistant, content: delta, tool_calls: nil, audio: nil, refusal: nil))
+            case "response.output_item.added":
+                // Surfaces the function-call skeleton (id/call_id/name). Arguments arrive
+                // via `response.function_call_arguments.delta`; `output_item.done` is skipped
+                // to avoid duplicating the accumulated arguments.
+                guard let item, item.type == "function_call" else { return nil }
+                return ResponseResponse(output: [item])
+            case "response.function_call_arguments.delta":
+                guard let delta else { return nil }
+                return ResponseResponse(output: [.init(type: "function_call", id: item_id, arguments: delta)])
+            case "response.completed", "response.incomplete", "response.failed":
+                guard let response else { return nil }
+                // The output has already been accumulated from deltas; surface only the
+                // terminal metadata (status, usage, id) to avoid duplicating content.
+                return ResponseResponse(
+                    id: response.id,
+                    object: response.object,
+                    created_at: response.created_at,
+                    model: response.model,
+                    status: response.status,
+                    output: [],
+                    usage: response.usage,
+                    error: response.error,
+                    incomplete_details: response.incomplete_details)
+            default:
+                return nil
+            }
+        }
+    }
+}

--- a/Sources/OpenAI/OpenAI+Response.swift
+++ b/Sources/OpenAI/OpenAI+Response.swift
@@ -140,6 +140,8 @@ public extension OpenAI {
                     break
                 }
             }
+            // A response whose output holds only reasoning/hosted-tool items has no assistant
+            // content to surface, so `nil` is correct; the raw items remain available via `output`.
             if text.isEmpty && calls.isEmpty { return nil }
             let content: Content = text.isEmpty ? .null : .string(text)
             return Item(role: .assistant, content: content, tool_calls: calls.isEmpty ? nil : calls)

--- a/Sources/OpenAI/OpenAI+Response.swift
+++ b/Sources/OpenAI/OpenAI+Response.swift
@@ -233,11 +233,26 @@ public extension OpenAI {
             public var type: String
             public var text: String?
             public var refusal: String?
+            /// Citations/references attached to `output_text` (e.g. from web/file search).
+            public var annotations: [Annotation]?
 
-            public init(type: String, text: String? = nil, refusal: String? = nil) {
+            public init(type: String, text: String? = nil, refusal: String? = nil, annotations: [Annotation]? = nil) {
                 self.type = type
                 self.text = text
                 self.refusal = refusal
+                self.annotations = annotations
+            }
+
+            public struct Annotation: Codable {
+                /// `url_citation`, `file_citation`, `file_path`, etc.
+                public let type: String
+                public let text: String?
+                public let start_index: Int?
+                public let end_index: Int?
+                public let url: String?
+                public let title: String?
+                public let file_id: String?
+                public let filename: String?
             }
         }
 

--- a/Sources/OpenAI/OpenAI+Response.swift
+++ b/Sources/OpenAI/OpenAI+Response.swift
@@ -197,7 +197,7 @@ public extension OpenAI {
                 else { mergedArguments = (arguments ?? "") + (next.arguments ?? "") }
                 let mergedContent: [OutputContent]?
                 switch (content, next.content) {
-                case (let a?, let b?): mergedContent = a + b
+                case (let a?, let b?): mergedContent = OutputItem.mergeContent(a, with: b)
                 case (let a?, nil): mergedContent = a
                 case (nil, let b?): mergedContent = b
                 case (nil, nil): mergedContent = nil
@@ -211,6 +211,20 @@ public extension OpenAI {
                     call_id: call_id ?? next.call_id,
                     name: name ?? next.name,
                     arguments: mergedArguments)
+            }
+
+            /// Appends `next` content parts, coalescing consecutive `output_text` parts into a
+            /// single entry so streamed text deltas don't accumulate one object per chunk.
+            static func mergeContent(_ base: [OutputContent], with next: [OutputContent]) -> [OutputContent] {
+                var result = base
+                for part in next {
+                    if part.type == "output_text", let last = result.indices.last, result[last].type == "output_text" {
+                        result[last].text = (result[last].text ?? "") + (part.text ?? "")
+                    } else {
+                        result.append(part)
+                    }
+                }
+                return result
             }
         }
 

--- a/Sources/OpenAI/OpenAI+ResponseItem.swift
+++ b/Sources/OpenAI/OpenAI+ResponseItem.swift
@@ -55,6 +55,19 @@ public extension OpenAI {
             self.tool_calls = role == .assistant ? tool_calls : nil
         }
 
+        /// Converts any message into an `Item`, preserving assistant tool calls (which the
+        /// default `LangToolsMessage.init(_:)` would drop) so that tool-call history survives
+        /// when a `ResponseRequest` is built from a heterogeneous `[any LangToolsMessage]`.
+        public init(_ message: any LangToolsMessage) {
+            if let openAIMessage = message as? OpenAI.Message, let calls = openAIMessage.tool_calls, !calls.isEmpty {
+                self.init(tool_selection: calls)
+            } else if let item = message as? Item, let calls = item.tool_calls, !calls.isEmpty {
+                self.init(tool_selection: calls)
+            } else {
+                self.init(role: Role(message.role), content: Content(message.content))
+            }
+        }
+
         public init(role: Role, content: String) {
             self.init(role: role, content: .string(content))
         }

--- a/Sources/OpenAI/OpenAI+ResponseItem.swift
+++ b/Sources/OpenAI/OpenAI+ResponseItem.swift
@@ -56,13 +56,13 @@ public extension OpenAI {
         }
 
         /// Converts any message into an `Item`, preserving assistant tool calls (which the
-        /// default `LangToolsMessage.init(_:)` would drop) so that tool-call history survives
-        /// when a `ResponseRequest` is built from a heterogeneous `[any LangToolsMessage]`.
+        /// default `LangToolsMessage.init(_:)` would drop) along with any accompanying text,
+        /// so tool-call history survives when a `ResponseRequest` is built from a heterogeneous
+        /// `[any LangToolsMessage]`.
         public init(_ message: any LangToolsMessage) {
-            if let openAIMessage = message as? OpenAI.Message, let calls = openAIMessage.tool_calls, !calls.isEmpty {
-                self.init(tool_selection: calls)
-            } else if let item = message as? Item, let calls = item.tool_calls, !calls.isEmpty {
-                self.init(tool_selection: calls)
+            let calls: [ToolSelection]? = (message as? OpenAI.Message)?.tool_calls ?? (message as? Item)?.tool_calls
+            if let calls, !calls.isEmpty {
+                self.init(role: .assistant, content: Content(message.content), tool_calls: calls)
             } else {
                 self.init(role: Role(message.role), content: Content(message.content))
             }

--- a/Sources/OpenAI/OpenAI+ResponseItem.swift
+++ b/Sources/OpenAI/OpenAI+ResponseItem.swift
@@ -112,8 +112,14 @@ public extension OpenAI {
 
         public func encode(to encoder: Encoder) throws {
             if let tool_calls, let first = tool_calls.first {
-                // A single function_call item. Items carrying multiple tool calls are
-                // flattened into multiple items by `ResponseRequest.encode(to:)`.
+                // A single function_call item. Items carrying multiple tool calls must be
+                // flattened into multiple items by `ResponseRequest.encode(to:)`; encoding
+                // such an Item on its own would silently drop calls, so fail loudly instead.
+                guard tool_calls.count == 1 else {
+                    throw EncodingError.invalidValue(tool_calls, EncodingError.Context(
+                        codingPath: encoder.codingPath,
+                        debugDescription: "An Item carrying multiple tool calls cannot be encoded directly; encode it via OpenAI.ResponseRequest, which flattens each call into its own function_call input item."))
+                }
                 var c = encoder.container(keyedBy: FunctionCallKeys.self)
                 try c.encode("function_call", forKey: .type)
                 try c.encodeIfPresent(first.id, forKey: .call_id)

--- a/Sources/OpenAI/OpenAI+ResponseItem.swift
+++ b/Sources/OpenAI/OpenAI+ResponseItem.swift
@@ -58,10 +58,13 @@ public extension OpenAI {
         /// Converts any message into an `Item`, preserving assistant tool calls (which the
         /// default `LangToolsMessage.init(_:)` would drop) along with any accompanying text,
         /// so tool-call history survives when a `ResponseRequest` is built from a heterogeneous
-        /// `[any LangToolsMessage]`.
+        /// `[any LangToolsMessage]` — including cross-provider conversations.
         public init(_ message: any LangToolsMessage) {
-            let calls: [ToolSelection]? = (message as? OpenAI.Message)?.tool_calls ?? (message as? Item)?.tool_calls
-            if let calls, !calls.isEmpty {
+            if let toolMessage = message as? any LangToolsToolMessage,
+               let selection = toolMessage.tool_selection, !selection.isEmpty {
+                let calls = selection.map { sel in
+                    ToolSelection(index: 0, id: sel.id ?? "", type: .function, function: .init(name: sel.name ?? "", arguments: sel.arguments))
+                }
                 self.init(role: .assistant, content: Content(message.content), tool_calls: calls)
             } else {
                 self.init(role: Role(message.role), content: Content(message.content))

--- a/Sources/OpenAI/OpenAI+ResponseItem.swift
+++ b/Sources/OpenAI/OpenAI+ResponseItem.swift
@@ -116,8 +116,10 @@ public extension OpenAI {
                     self.content = .array([.toolResult(.init(tool_selection_id: callID, result: output))])
                     self.tool_calls = nil
                     return
+                case "message":
+                    break // a typed message item — fall through to the message decode below
                 default:
-                    break
+                    throw DecodingError.dataCorruptedError(forKey: .type, in: fc, debugDescription: "Unsupported input item type: \(type)")
                 }
             }
             let container = try decoder.container(keyedBy: MessageKeys.self)
@@ -183,7 +185,7 @@ public extension OpenAI {
             case .string(let str):
                 try container.encode(str, forKey: .content)
             case .null:
-                try container.encode("", forKey: .content)
+                break // omit the content key entirely; the API rejects "content": ""
             case .array(let parts):
                 var arr = container.nestedUnkeyedContainer(forKey: .content)
                 for part in parts {

--- a/Sources/OpenAI/OpenAI+ResponseItem.swift
+++ b/Sources/OpenAI/OpenAI+ResponseItem.swift
@@ -133,6 +133,19 @@ public extension OpenAI {
                         codingPath: encoder.codingPath,
                         debugDescription: "An Item carrying multiple tool calls cannot be encoded directly; encode it via OpenAI.ResponseRequest, which flattens each call into its own function_call input item."))
                 }
+                // Text alongside a tool call also cannot be represented as a single item;
+                // ResponseRequest.encode emits the text as a separate message item.
+                let hasText: Bool
+                switch content {
+                case .null: hasText = false
+                case .string(let s): hasText = !s.isEmpty
+                case .array(let a): hasText = !a.isEmpty
+                }
+                guard !hasText else {
+                    throw EncodingError.invalidValue(content, EncodingError.Context(
+                        codingPath: encoder.codingPath,
+                        debugDescription: "An Item carrying both text and a tool call cannot be encoded directly; encode it via OpenAI.ResponseRequest, which emits the text as a separate message item."))
+                }
                 var c = encoder.container(keyedBy: FunctionCallKeys.self)
                 try c.encode("function_call", forKey: .type)
                 try c.encodeIfPresent(first.id, forKey: .call_id)

--- a/Sources/OpenAI/OpenAI+ResponseItem.swift
+++ b/Sources/OpenAI/OpenAI+ResponseItem.swift
@@ -62,8 +62,8 @@ public extension OpenAI {
         public init(_ message: any LangToolsMessage) {
             if let toolMessage = message as? any LangToolsToolMessage,
                let selection = toolMessage.tool_selection, !selection.isEmpty {
-                let calls = selection.map { sel in
-                    ToolSelection(index: 0, id: sel.id ?? "", type: .function, function: .init(name: sel.name ?? "", arguments: sel.arguments))
+                let calls = selection.enumerated().map { index, sel in
+                    ToolSelection(index: index, id: sel.id ?? "", type: .function, function: .init(name: sel.name ?? "", arguments: sel.arguments))
                 }
                 self.init(role: .assistant, content: Content(message.content), tool_calls: calls)
             } else {
@@ -138,13 +138,7 @@ public extension OpenAI {
                 }
                 // Text alongside a tool call also cannot be represented as a single item;
                 // ResponseRequest.encode emits the text as a separate message item.
-                let hasText: Bool
-                switch content {
-                case .null: hasText = false
-                case .string(let s): hasText = !s.isEmpty
-                case .array(let a): hasText = !a.isEmpty
-                }
-                guard !hasText else {
+                guard !Item.hasEncodableContent(content) else {
                     throw EncodingError.invalidValue(content, EncodingError.Context(
                         codingPath: encoder.codingPath,
                         debugDescription: "An Item carrying both text and a tool call cannot be encoded directly; encode it via OpenAI.ResponseRequest, which emits the text as a separate message item."))
@@ -163,6 +157,22 @@ public extension OpenAI {
                 var c = encoder.container(keyedBy: MessageKeys.self)
                 try c.encode(role, forKey: .role)
                 try Item.encodeContent(content, into: &c)
+            }
+        }
+
+        /// Whether `encodeContent` would emit any content for this value — i.e. a non-empty
+        /// string or an array containing at least one text/image part (the only parts
+        /// `encodeContent` serialises). Used to avoid emitting an empty `content` block.
+        static func hasEncodableContent(_ content: Content) -> Bool {
+            switch content {
+            case .null: return false
+            case .string(let str): return !str.isEmpty
+            case .array(let parts):
+                return parts.contains {
+                    if case .text = $0 { return true }
+                    if case .image = $0 { return true }
+                    return false
+                }
             }
         }
 

--- a/Sources/OpenAI/OpenAI+ResponseItem.swift
+++ b/Sources/OpenAI/OpenAI+ResponseItem.swift
@@ -1,0 +1,167 @@
+//
+//  OpenAI+ResponseItem.swift
+//  OpenAI
+//
+//  Responses API input/conversation item.
+//
+
+import Foundation
+import LangTools
+
+
+public extension OpenAI {
+    /// A single conversation item used by the Responses API.
+    ///
+    /// The Responses API models a conversation as an array of `input` items rather than
+    /// chat-style `messages`. An item can be a plain message (`role` + `content`), an
+    /// assistant `function_call`, or a `function_call_output` carrying a tool result.
+    ///
+    /// To maximise reuse and cross-provider conversion, `Item` reuses the existing
+    /// `OpenAI.Message` value types (`Role`, `Content`, `ToolCall`, `ToolResultContent`).
+    struct Item: Codable, CustomStringConvertible, LangToolsMessage, LangToolsToolMessage {
+        public typealias Role = OpenAI.Message.Role
+        public typealias Content = OpenAI.Message.Content
+        public typealias ToolSelection = OpenAI.Message.ToolCall
+        public typealias ToolResult = OpenAI.Message.Content.ToolResultContent
+
+        public let role: Role
+        public let content: Content
+        public let tool_calls: [ToolSelection]?
+
+        public var tool_selection: [ToolSelection]? { tool_calls }
+
+        var toolResult: ToolResult? {
+            if case .toolResult(let tool) = content.array?.first { return tool }; return nil
+        }
+
+        public var tool_selection_id: String { toolResult?.tool_selection_id ?? "no id" }
+
+        public var description: String {
+            let tools = tool_calls?.map { $0.function.name ?? "" }.joined(separator: ",")
+            return "Item(role: \(role.rawValue), content: \(content), tool_calls: \(tools ?? ""))"
+        }
+
+        // MARK: - Initializers
+
+        public init(role: Role, content: Content) {
+            self.role = role
+            self.content = content
+            self.tool_calls = nil
+        }
+
+        public init(role: Role, content: Content, tool_calls: [ToolSelection]?) {
+            self.role = role
+            self.content = content
+            self.tool_calls = role == .assistant ? tool_calls : nil
+        }
+
+        public init(role: Role, content: String) {
+            self.init(role: role, content: .string(content))
+        }
+
+        public init(tool_selection: [ToolSelection]) {
+            self.role = .assistant
+            self.content = .null
+            self.tool_calls = tool_selection
+        }
+
+        public init(tool_selection_id: String, result: String) {
+            self.role = .tool
+            self.content = .array([.toolResult(.init(tool_selection_id: tool_selection_id, result: result))])
+            self.tool_calls = nil
+        }
+
+        public static func messages(for tool_results: [ToolResult]) -> [Item] {
+            return tool_results.map { Item(tool_selection_id: $0.tool_selection_id, result: $0.result) }
+        }
+
+        // MARK: - Codable (Responses wire format)
+
+        enum MessageKeys: String, CodingKey { case type, role, content }
+        enum FunctionCallKeys: String, CodingKey { case type, call_id, name, arguments, output }
+
+        public init(from decoder: Decoder) throws {
+            // Peek at the discriminator `type` to detect function_call / function_call_output items.
+            if let fc = try? decoder.container(keyedBy: FunctionCallKeys.self),
+               let type = try? fc.decode(String.self, forKey: .type) {
+                switch type {
+                case "function_call":
+                    let callID = try fc.decodeIfPresent(String.self, forKey: .call_id)
+                    let name = try fc.decodeIfPresent(String.self, forKey: .name)
+                    let arguments = try fc.decodeIfPresent(String.self, forKey: .arguments) ?? ""
+                    self.role = .assistant
+                    self.content = .null
+                    self.tool_calls = [ToolSelection(index: 0, id: callID ?? "", type: .function, function: .init(name: name ?? "", arguments: arguments))]
+                    return
+                case "function_call_output":
+                    let callID = try fc.decode(String.self, forKey: .call_id)
+                    let output = try fc.decodeIfPresent(String.self, forKey: .output) ?? ""
+                    self.role = .tool
+                    self.content = .array([.toolResult(.init(tool_selection_id: callID, result: output))])
+                    self.tool_calls = nil
+                    return
+                default:
+                    break
+                }
+            }
+            let container = try decoder.container(keyedBy: MessageKeys.self)
+            self.role = try container.decode(Role.self, forKey: .role)
+            self.content = try container.decodeIfPresent(Content.self, forKey: .content) ?? .null
+            self.tool_calls = nil
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            if let tool_calls, let first = tool_calls.first {
+                // A single function_call item. Items carrying multiple tool calls are
+                // flattened into multiple items by `ResponseRequest.encode(to:)`.
+                var c = encoder.container(keyedBy: FunctionCallKeys.self)
+                try c.encode("function_call", forKey: .type)
+                try c.encodeIfPresent(first.id, forKey: .call_id)
+                try c.encodeIfPresent(first.name, forKey: .name)
+                try c.encode(first.arguments, forKey: .arguments)
+            } else if let toolResult {
+                var c = encoder.container(keyedBy: FunctionCallKeys.self)
+                try c.encode("function_call_output", forKey: .type)
+                try c.encode(toolResult.tool_selection_id, forKey: .call_id)
+                try c.encode(toolResult.result, forKey: .output)
+            } else {
+                var c = encoder.container(keyedBy: MessageKeys.self)
+                try c.encode(role, forKey: .role)
+                try Item.encodeContent(content, into: &c)
+            }
+        }
+
+        /// Encodes message content using the Responses API input content-part shapes
+        /// (`input_text` / `input_image`). Plain string content is encoded directly.
+        static func encodeContent(_ content: Content, into container: inout KeyedEncodingContainer<MessageKeys>) throws {
+            switch content {
+            case .string(let str):
+                try container.encode(str, forKey: .content)
+            case .null:
+                try container.encode("", forKey: .content)
+            case .array(let parts):
+                var arr = container.nestedUnkeyedContainer(forKey: .content)
+                for part in parts {
+                    switch part {
+                    case .text(let text):
+                        try arr.encode(InputTextPart(text: text.text))
+                    case .image(let image):
+                        try arr.encode(InputImagePart(image_url: image.image_url.url))
+                    default:
+                        break // refusals / tool results are not valid input content parts
+                    }
+                }
+            }
+        }
+
+        struct InputTextPart: Encodable {
+            let type = "input_text"
+            let text: String
+        }
+
+        struct InputImagePart: Encodable {
+            let type = "input_image"
+            let image_url: String
+        }
+    }
+}

--- a/Sources/OpenAI/OpenAI+ResponseRequest.swift
+++ b/Sources/OpenAI/OpenAI+ResponseRequest.swift
@@ -147,6 +147,13 @@ public extension OpenAI {
             var input = container.nestedUnkeyedContainer(forKey: .input)
             for item in messages {
                 if let tool_calls = item.tool_calls, !tool_calls.isEmpty {
+                    // An assistant turn may carry text alongside its tool calls; emit the text
+                    // as its own message item so it is preserved in the conversation.
+                    if let text = item.content.string, !text.isEmpty {
+                        var mc = input.nestedContainer(keyedBy: Item.MessageKeys.self)
+                        try mc.encode(item.role, forKey: .role)
+                        try mc.encode(text, forKey: .content)
+                    }
                     for call in tool_calls {
                         var c = input.nestedContainer(keyedBy: Item.FunctionCallKeys.self)
                         try c.encode("function_call", forKey: .type)

--- a/Sources/OpenAI/OpenAI+ResponseRequest.swift
+++ b/Sources/OpenAI/OpenAI+ResponseRequest.swift
@@ -202,7 +202,7 @@ public extension OpenAI {
                 self.summary = summary
             }
 
-            public enum Effort: String, Codable { case minimal, low, medium, high }
+            public enum Effort: String, Codable { case minimal, low, medium, high, xhigh }
             public enum Summary: String, Codable { case auto, concise, detailed }
         }
 

--- a/Sources/OpenAI/OpenAI+ResponseRequest.swift
+++ b/Sources/OpenAI/OpenAI+ResponseRequest.swift
@@ -270,6 +270,9 @@ public extension OpenAI {
         public enum ToolChoice: Codable {
             case none, auto, required
             case function(name: String)
+            /// Forces a hosted tool by its type, e.g. `.hostedTool("file_search")` or
+            /// `.hostedTool("web_search")` — encoded as `{"type": "<type>"}` with no name.
+            case hostedTool(String)
 
             enum CodingKeys: String, CodingKey { case type, name }
 
@@ -285,11 +288,12 @@ public extension OpenAI {
                 }
                 let container = try decoder.container(keyedBy: CodingKeys.self)
                 let type = try container.decode(String.self, forKey: .type)
-                guard type == "function" else {
-                    throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unsupported tool_choice type: \(type)")
+                if type == "function" {
+                    let name = try container.decode(String.self, forKey: .name)
+                    self = .function(name: name)
+                } else {
+                    self = .hostedTool(type)
                 }
-                let name = try container.decode(String.self, forKey: .name)
-                self = .function(name: name)
             }
 
             public func encode(to encoder: Encoder) throws {
@@ -307,6 +311,9 @@ public extension OpenAI {
                     var container = encoder.container(keyedBy: CodingKeys.self)
                     try container.encode("function", forKey: .type)
                     try container.encode(name, forKey: .name)
+                case .hostedTool(let type):
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    try container.encode(type, forKey: .type)
                 }
             }
         }

--- a/Sources/OpenAI/OpenAI+ResponseRequest.swift
+++ b/Sources/OpenAI/OpenAI+ResponseRequest.swift
@@ -1,0 +1,408 @@
+//
+//  OpenAI+ResponseRequest.swift
+//  OpenAI
+//
+//  OpenAI Responses API — https://platform.openai.com/docs/api-reference/responses
+//
+
+import Foundation
+import LangTools
+
+
+public extension OpenAI {
+    /// Convenience for performing a Responses API request with a closure-based completion.
+    func performResponseRequest(messages: [Item], model: Model = .gpt4o_mini, stream: Bool = false, completion: @escaping (Result<OpenAI.ResponseResponse, Error>) -> Void, didCompleteStreaming: ((Error?) -> Void)? = nil) {
+        perform(request: OpenAI.ResponseRequest(model: model, messages: messages, stream: stream), completion: completion, didCompleteStreaming: didCompleteStreaming)
+    }
+
+    /// A request to the Responses API (`POST /v1/responses`).
+    struct ResponseRequest: Codable, LangToolsChatRequest, LangToolsStreamableRequest, LangToolsToolCallingRequest, LangToolsStructuredOutputRequest {
+        public typealias LangTool = OpenAI
+        public typealias Response = ResponseResponse
+        public static var endpoint: String { "responses" }
+
+        public let model: Model
+        /// The conversation, sent on the wire as `input`.
+        public var messages: [Item]
+        /// A system/developer message inserted into the model's context.
+        public var instructions: String?
+        public var tools: [Tool]?
+        public var tool_choice: ToolChoice?
+        public var temperature: Double?
+        public var top_p: Double?
+        public var max_output_tokens: Int?
+        public var top_logprobs: Int?
+        public var parallel_tool_calls: Bool?
+        /// The id of a previous response to continue from (server-side conversation state).
+        public var previous_response_id: String?
+        public var store: Bool?
+        public var stream: Bool?
+        public var reasoning: Reasoning?
+        public var text: TextConfig?
+        public var metadata: [String: String]?
+        public var include: [String]?
+        public var truncation: String?
+        public var user: String?
+
+        public var toolEventHandler: ((LangToolsToolEvent) -> Void)?
+
+        // MARK: - LangToolsStructuredOutputRequest
+
+        /// The response schema for structured output. Setting it configures `text.format`
+        /// to use the `json_schema` type with strict mode enabled.
+        public var responseSchema: JSONSchema? {
+            get {
+                if case .json_schema(let format)? = text?.format { return format.schema }
+                return nil
+            }
+            set {
+                if let schema = newValue {
+                    text = TextConfig(format: .json_schema(.init(
+                        name: schema.title ?? "structured_response",
+                        schema: schema,
+                        strict: true)))
+                } else if case .json_schema? = text?.format {
+                    text = nil
+                }
+            }
+        }
+
+        /// Returns `true` when the request is configured with a structured output schema.
+        public var usesStructuredOutput: Bool {
+            if case .json_schema? = text?.format { return true }
+            return false
+        }
+
+        // MARK: - Initializers
+
+        public init(model: Model, messages: [any LangToolsMessage]) {
+            self.init(model: model, messages: messages.map { Item($0) })
+        }
+
+        public init(model: Model, messages: [Item], instructions: String? = nil, tools: [Tool]? = nil, tool_choice: ToolChoice? = nil, temperature: Double? = nil, top_p: Double? = nil, max_output_tokens: Int? = nil, top_logprobs: Int? = nil, parallel_tool_calls: Bool? = nil, previous_response_id: String? = nil, store: Bool? = nil, stream: Bool? = nil, reasoning: Reasoning? = nil, text: TextConfig? = nil, metadata: [String: String]? = nil, include: [String]? = nil, truncation: String? = nil, user: String? = nil, toolEventHandler: @escaping (LangToolsToolEvent) -> Void = { _ in }) {
+            self.model = model
+            self.messages = messages
+            self.instructions = instructions
+            self.tools = tools
+            self.tool_choice = tool_choice
+            self.temperature = temperature
+            self.top_p = top_p
+            self.max_output_tokens = max_output_tokens
+            self.top_logprobs = top_logprobs
+            self.parallel_tool_calls = parallel_tool_calls
+            self.previous_response_id = previous_response_id
+            self.store = store
+            self.stream = stream
+            self.reasoning = reasoning
+            self.text = text
+            self.metadata = metadata
+            self.include = include
+            self.truncation = truncation
+            self.user = user
+            self.toolEventHandler = toolEventHandler
+        }
+
+        // MARK: - Codable
+
+        enum CodingKeys: String, CodingKey {
+            case model, input, instructions, tools, tool_choice, temperature, top_p
+            case max_output_tokens, top_logprobs, parallel_tool_calls, previous_response_id
+            case store, stream, reasoning, text, metadata, include, truncation, user
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            model = try container.decode(Model.self, forKey: .model)
+            if let string = try? container.decode(String.self, forKey: .input) {
+                messages = [Item(role: .user, content: .string(string))]
+            } else {
+                messages = (try? container.decode([Item].self, forKey: .input)) ?? []
+            }
+            instructions = try container.decodeIfPresent(String.self, forKey: .instructions)
+            tools = try container.decodeIfPresent([Tool].self, forKey: .tools)
+            tool_choice = try container.decodeIfPresent(ToolChoice.self, forKey: .tool_choice)
+            temperature = try container.decodeIfPresent(Double.self, forKey: .temperature)
+            top_p = try container.decodeIfPresent(Double.self, forKey: .top_p)
+            max_output_tokens = try container.decodeIfPresent(Int.self, forKey: .max_output_tokens)
+            top_logprobs = try container.decodeIfPresent(Int.self, forKey: .top_logprobs)
+            parallel_tool_calls = try container.decodeIfPresent(Bool.self, forKey: .parallel_tool_calls)
+            previous_response_id = try container.decodeIfPresent(String.self, forKey: .previous_response_id)
+            store = try container.decodeIfPresent(Bool.self, forKey: .store)
+            stream = try container.decodeIfPresent(Bool.self, forKey: .stream)
+            reasoning = try container.decodeIfPresent(Reasoning.self, forKey: .reasoning)
+            text = try container.decodeIfPresent(TextConfig.self, forKey: .text)
+            metadata = try container.decodeIfPresent([String: String].self, forKey: .metadata)
+            include = try container.decodeIfPresent([String].self, forKey: .include)
+            truncation = try container.decodeIfPresent(String.self, forKey: .truncation)
+            user = try container.decodeIfPresent(String.self, forKey: .user)
+            toolEventHandler = nil
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(model, forKey: .model)
+
+            // `input` is a heterogeneous array: assistant tool calls and tool results are
+            // flattened into their own `function_call` / `function_call_output` items.
+            var input = container.nestedUnkeyedContainer(forKey: .input)
+            for item in messages {
+                if let tool_calls = item.tool_calls, !tool_calls.isEmpty {
+                    for call in tool_calls {
+                        var c = input.nestedContainer(keyedBy: Item.FunctionCallKeys.self)
+                        try c.encode("function_call", forKey: .type)
+                        try c.encodeIfPresent(call.id, forKey: .call_id)
+                        try c.encodeIfPresent(call.name, forKey: .name)
+                        try c.encode(call.arguments, forKey: .arguments)
+                    }
+                } else if let toolResult = item.toolResult {
+                    var c = input.nestedContainer(keyedBy: Item.FunctionCallKeys.self)
+                    try c.encode("function_call_output", forKey: .type)
+                    try c.encode(toolResult.tool_selection_id, forKey: .call_id)
+                    try c.encode(toolResult.result, forKey: .output)
+                } else {
+                    var c = input.nestedContainer(keyedBy: Item.MessageKeys.self)
+                    try c.encode(item.role, forKey: .role)
+                    try Item.encodeContent(item.content, into: &c)
+                }
+            }
+
+            try container.encodeIfPresent(instructions, forKey: .instructions)
+            try container.encodeIfPresent(tools, forKey: .tools)
+            try container.encodeIfPresent(tool_choice, forKey: .tool_choice)
+            try container.encodeIfPresent(temperature, forKey: .temperature)
+            try container.encodeIfPresent(top_p, forKey: .top_p)
+            try container.encodeIfPresent(max_output_tokens, forKey: .max_output_tokens)
+            try container.encodeIfPresent(top_logprobs, forKey: .top_logprobs)
+            try container.encodeIfPresent(parallel_tool_calls, forKey: .parallel_tool_calls)
+            try container.encodeIfPresent(previous_response_id, forKey: .previous_response_id)
+            try container.encodeIfPresent(store, forKey: .store)
+            try container.encodeIfPresent(stream, forKey: .stream)
+            try container.encodeIfPresent(reasoning, forKey: .reasoning)
+            try container.encodeIfPresent(text, forKey: .text)
+            try container.encodeIfPresent(metadata, forKey: .metadata)
+            try container.encodeIfPresent(include, forKey: .include)
+            try container.encodeIfPresent(truncation, forKey: .truncation)
+            try container.encodeIfPresent(user, forKey: .user)
+        }
+
+        // MARK: - Reasoning
+
+        public struct Reasoning: Codable {
+            public var effort: Effort?
+            public var summary: Summary?
+
+            public init(effort: Effort? = nil, summary: Summary? = nil) {
+                self.effort = effort
+                self.summary = summary
+            }
+
+            public enum Effort: String, Codable { case minimal, low, medium, high }
+            public enum Summary: String, Codable { case auto, concise, detailed }
+        }
+
+        // MARK: - Text / structured output configuration
+
+        public struct TextConfig: Codable {
+            public var format: Format
+
+            public init(format: Format) { self.format = format }
+
+            public enum Format: Codable {
+                case text
+                case json_object
+                case json_schema(JSONSchemaFormat)
+
+                public struct JSONSchemaFormat: Codable {
+                    public let name: String
+                    public let schema: JSONSchema
+                    public let strict: Bool
+
+                    public init(name: String, schema: JSONSchema, strict: Bool = true) {
+                        self.name = ChatCompletionRequest.ResponseFormat.JSONSchemaFormat.sanitize(name: name)
+                        self.schema = schema
+                        self.strict = strict
+                    }
+                }
+
+                enum CodingKeys: String, CodingKey { case type, name, schema, strict }
+
+                public init(from decoder: Decoder) throws {
+                    let container = try decoder.container(keyedBy: CodingKeys.self)
+                    switch try container.decode(String.self, forKey: .type) {
+                    case "text": self = .text
+                    case "json_object": self = .json_object
+                    case "json_schema":
+                        self = .json_schema(.init(
+                            name: try container.decode(String.self, forKey: .name),
+                            schema: try container.decode(JSONSchema.self, forKey: .schema),
+                            strict: try container.decodeIfPresent(Bool.self, forKey: .strict) ?? true))
+                    case let type:
+                        throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unknown text.format type: \(type)")
+                    }
+                }
+
+                public func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    switch self {
+                    case .text:
+                        try container.encode("text", forKey: .type)
+                    case .json_object:
+                        try container.encode("json_object", forKey: .type)
+                    case .json_schema(let format):
+                        // The Responses API flattens name/schema/strict alongside `type`.
+                        try container.encode("json_schema", forKey: .type)
+                        try container.encode(format.name, forKey: .name)
+                        try container.encode(format.schema, forKey: .schema)
+                        try container.encode(format.strict, forKey: .strict)
+                    }
+                }
+            }
+        }
+
+        // MARK: - Tool choice
+
+        public enum ToolChoice: Codable {
+            case none, auto, required
+            case function(name: String)
+
+            enum CodingKeys: String, CodingKey { case type, name }
+
+            public init(from decoder: Decoder) throws {
+                if let container = try? decoder.singleValueContainer(), let string = try? container.decode(String.self) {
+                    switch string {
+                    case "none": self = .none
+                    case "auto": self = .auto
+                    case "required": self = .required
+                    default: throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid tool_choice: \(string)")
+                    }
+                    return
+                }
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let name = try container.decode(String.self, forKey: .name)
+                self = .function(name: name)
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                switch self {
+                case .none:
+                    var container = encoder.singleValueContainer()
+                    try container.encode("none")
+                case .auto:
+                    var container = encoder.singleValueContainer()
+                    try container.encode("auto")
+                case .required:
+                    var container = encoder.singleValueContainer()
+                    try container.encode("required")
+                case .function(let name):
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    try container.encode("function", forKey: .type)
+                    try container.encode(name, forKey: .name)
+                }
+            }
+        }
+
+        // MARK: - Tool
+
+        /// A tool the model may call. Function tools support the LangTools callback-based
+        /// tool-calling loop; the hosted tools (`web_search`, `file_search`, …) are server-side.
+        public enum Tool: Codable, LangToolsTool {
+            public typealias ToolSchema = OpenAI.Tool.FunctionSchema.Parameters
+
+            case function(Function)
+            case webSearch
+            case webSearchPreview
+            case fileSearch(vectorStoreIDs: [String])
+            case codeInterpreter
+            case imageGeneration
+
+            public struct Function {
+                public var name: String
+                public var description: String?
+                public var parameters: ToolSchema
+                public var strict: Bool?
+                public var callback: ((LangToolsRequestInfo, [String: JSON]) async throws -> String?)?
+
+                public init(name: String, description: String? = nil, parameters: ToolSchema = .init(), strict: Bool? = nil, callback: ((LangToolsRequestInfo, [String: JSON]) async throws -> String?)? = nil) {
+                    self.name = name
+                    self.description = description
+                    self.parameters = parameters
+                    self.strict = strict
+                    self.callback = callback
+                }
+            }
+
+            // LangToolsTool conformance
+            public init(name: String, description: String?, tool_schema: ToolSchema, callback: ((LangToolsRequestInfo, [String: JSON]) async throws -> String?)?) {
+                self = .function(.init(name: name, description: description, parameters: tool_schema, callback: callback))
+            }
+
+            public var name: String {
+                switch self {
+                case .function(let f): return f.name
+                case .webSearch: return "web_search"
+                case .webSearchPreview: return "web_search_preview"
+                case .fileSearch: return "file_search"
+                case .codeInterpreter: return "code_interpreter"
+                case .imageGeneration: return "image_generation"
+                }
+            }
+
+            public var description: String? {
+                if case .function(let f) = self { return f.description }; return nil
+            }
+
+            public var tool_schema: ToolSchema {
+                if case .function(let f) = self { return f.parameters }; return .init()
+            }
+
+            public var callback: ((LangToolsRequestInfo, [String: JSON]) async throws -> String?)? {
+                if case .function(let f) = self { return f.callback }; return nil
+            }
+
+            enum CodingKeys: String, CodingKey { case type, name, description, parameters, strict, vector_store_ids }
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                switch try container.decode(String.self, forKey: .type) {
+                case "function":
+                    self = .function(.init(
+                        name: try container.decode(String.self, forKey: .name),
+                        description: try container.decodeIfPresent(String.self, forKey: .description),
+                        parameters: try container.decodeIfPresent(ToolSchema.self, forKey: .parameters) ?? .init(),
+                        strict: try container.decodeIfPresent(Bool.self, forKey: .strict),
+                        callback: nil))
+                case "web_search": self = .webSearch
+                case "web_search_preview": self = .webSearchPreview
+                case "file_search": self = .fileSearch(vectorStoreIDs: try container.decodeIfPresent([String].self, forKey: .vector_store_ids) ?? [])
+                case "code_interpreter": self = .codeInterpreter
+                case "image_generation": self = .imageGeneration
+                case let type:
+                    throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unknown tool type: \(type)")
+                }
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                switch self {
+                case .function(let f):
+                    try container.encode("function", forKey: .type)
+                    try container.encode(f.name, forKey: .name)
+                    try container.encodeIfPresent(f.description, forKey: .description)
+                    try container.encode(f.parameters, forKey: .parameters)
+                    try container.encodeIfPresent(f.strict, forKey: .strict)
+                case .webSearch:
+                    try container.encode("web_search", forKey: .type)
+                case .webSearchPreview:
+                    try container.encode("web_search_preview", forKey: .type)
+                case .fileSearch(let ids):
+                    try container.encode("file_search", forKey: .type)
+                    try container.encode(ids, forKey: .vector_store_ids)
+                case .codeInterpreter:
+                    try container.encode("code_interpreter", forKey: .type)
+                case .imageGeneration:
+                    try container.encode("image_generation", forKey: .type)
+                }
+            }
+        }
+    }
+}

--- a/Sources/OpenAI/OpenAI+ResponseRequest.swift
+++ b/Sources/OpenAI/OpenAI+ResponseRequest.swift
@@ -146,12 +146,18 @@ public extension OpenAI {
             var input = container.nestedUnkeyedContainer(forKey: .input)
             for item in messages {
                 if let tool_calls = item.tool_calls, !tool_calls.isEmpty {
-                    // An assistant turn may carry text alongside its tool calls; emit the text
-                    // as its own message item so it is preserved in the conversation.
-                    if let text = item.content.string, !text.isEmpty {
+                    // An assistant turn may carry text (string or multipart) alongside its tool
+                    // calls; emit it as its own message item so it is preserved in the conversation.
+                    let hasContent: Bool
+                    switch item.content {
+                    case .null: hasContent = false
+                    case .string(let s): hasContent = !s.isEmpty
+                    case .array(let a): hasContent = !a.isEmpty
+                    }
+                    if hasContent {
                         var mc = input.nestedContainer(keyedBy: Item.MessageKeys.self)
                         try mc.encode(item.role, forKey: .role)
-                        try mc.encode(text, forKey: .content)
+                        try Item.encodeContent(item.content, into: &mc)
                     }
                     for call in tool_calls {
                         var c = input.nestedContainer(keyedBy: Item.FunctionCallKeys.self)

--- a/Sources/OpenAI/OpenAI+ResponseRequest.swift
+++ b/Sources/OpenAI/OpenAI+ResponseRequest.swift
@@ -68,10 +68,7 @@ public extension OpenAI {
         }
 
         /// Returns `true` when the request is configured with a structured output schema.
-        public var usesStructuredOutput: Bool {
-            if case .json_schema? = text?.format { return true }
-            return false
-        }
+        public var usesStructuredOutput: Bool { responseSchema != nil }
 
         // MARK: - Initializers
 
@@ -116,7 +113,9 @@ public extension OpenAI {
             if let string = try? container.decode(String.self, forKey: .input) {
                 messages = [Item(role: .user, content: .string(string))]
             } else {
-                messages = (try? container.decode([Item].self, forKey: .input)) ?? []
+                // decodeIfPresent (not try?) so a malformed item surfaces an error rather than
+                // silently discarding the whole conversation; absent `input` tolerates to [].
+                messages = try container.decodeIfPresent([Item].self, forKey: .input) ?? []
             }
             instructions = try container.decodeIfPresent(String.self, forKey: .instructions)
             tools = try container.decodeIfPresent([Tool].self, forKey: .tools)

--- a/Sources/OpenAI/OpenAI+ResponseRequest.swift
+++ b/Sources/OpenAI/OpenAI+ResponseRequest.swift
@@ -148,13 +148,7 @@ public extension OpenAI {
                 if let tool_calls = item.tool_calls, !tool_calls.isEmpty {
                     // An assistant turn may carry text (string or multipart) alongside its tool
                     // calls; emit it as its own message item so it is preserved in the conversation.
-                    let hasContent: Bool
-                    switch item.content {
-                    case .null: hasContent = false
-                    case .string(let s): hasContent = !s.isEmpty
-                    case .array(let a): hasContent = !a.isEmpty
-                    }
-                    if hasContent {
+                    if Item.hasEncodableContent(item.content) {
                         var mc = input.nestedContainer(keyedBy: Item.MessageKeys.self)
                         try mc.encode(item.role, forKey: .role)
                         try Item.encodeContent(item.content, into: &mc)

--- a/Sources/OpenAI/OpenAI+ResponseRequest.swift
+++ b/Sources/OpenAI/OpenAI+ResponseRequest.swift
@@ -218,7 +218,7 @@ public extension OpenAI {
                     public let strict: Bool
 
                     public init(name: String, schema: JSONSchema, strict: Bool = true) {
-                        self.name = ChatCompletionRequest.ResponseFormat.JSONSchemaFormat.sanitize(name: name)
+                        self.name = OpenAI.sanitizeSchemaName(name)
                         self.schema = schema
                         self.strict = strict
                     }

--- a/Sources/OpenAI/OpenAI+ResponseRequest.swift
+++ b/Sources/OpenAI/OpenAI+ResponseRequest.swift
@@ -290,6 +290,10 @@ public extension OpenAI {
                     return
                 }
                 let container = try decoder.container(keyedBy: CodingKeys.self)
+                let type = try container.decode(String.self, forKey: .type)
+                guard type == "function" else {
+                    throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unsupported tool_choice type: \(type)")
+                }
                 let name = try container.decode(String.self, forKey: .name)
                 self = .function(name: name)
             }

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -35,12 +35,29 @@ final public class OpenAI: LangTools {
     public static var requestValidators: [(any LangToolsRequest) -> Bool] {
         return [
             { ($0 as? ChatCompletionRequest).flatMap { OpenAIModel.openAIModels.contains($0.model) } ?? false },
+            { $0 is ResponseRequest },
             { $0 is AudioSpeechRequest },
             { $0 is AudioTranscriptionRequest },
             { $0 is ListModelDataRequest },
             { $0 is RetrieveModelRequest },
             { $0 is DeleteFineTunedModelRequest }
         ]
+    }
+
+    /// Decodes a single SSE line from the stream.
+    ///
+    /// The Responses API streams *semantic events* rather than full response chunks, so
+    /// each event is mapped onto a partial ``ResponseResponse`` (events with no incremental
+    /// payload yield `nil` and are skipped). All other request types fall back to decoding
+    /// the `data:` payload directly as the response type.
+    public static func decodeStream<T: Decodable>(_ buffer: String) throws -> T? {
+        guard buffer.hasPrefix("data:"), !buffer.contains("[DONE]"),
+              let data = buffer.dropFirst(5).data(using: .utf8) else { return nil }
+        if T.self == ResponseResponse.self {
+            let event: ResponseStreamEvent = try decodeResponse(data: data)
+            return event.partialResponse as? T
+        }
+        return try decodeResponse(data: data)
     }
 
     public init(baseURL: URL = URL(string: "https://api.openai.com/v1/")!, apiKey: String, session: URLSession = URLSession(configuration: .default, delegate: nil, delegateQueue: nil)) {

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -101,6 +101,21 @@ final public class OpenAI: LangTools {
     }
 }
 
+extension OpenAI {
+    /// Sanitises a structured-output schema name to OpenAI's required pattern
+    /// `^[a-zA-Z0-9_-]{1,64}$`: non-conforming characters become `_`, the result is
+    /// truncated to 64 characters, and an empty result falls back to `"structured_response"`.
+    static func sanitizeSchemaName(_ name: String) -> String {
+        let cleaned = name
+            .unicodeScalars
+            .map { CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_-")).contains($0) ? Character($0) : "_" }
+            .map(String.init)
+            .joined()
+        let truncated = String(cleaned.prefix(64))
+        return truncated.isEmpty ? "structured_response" : truncated
+    }
+}
+
 public struct OpenAIErrorResponse: Error, Codable {
     public let error: APIError
 

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -102,13 +102,15 @@ final public class OpenAI: LangTools {
 }
 
 extension OpenAI {
+    private static let schemaNameAllowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_-"))
+
     /// Sanitises a structured-output schema name to OpenAI's required pattern
     /// `^[a-zA-Z0-9_-]{1,64}$`: non-conforming characters become `_`, the result is
     /// truncated to 64 characters, and an empty result falls back to `"structured_response"`.
     static func sanitizeSchemaName(_ name: String) -> String {
         let cleaned = name
             .unicodeScalars
-            .map { CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_-")).contains($0) ? Character($0) : "_" }
+            .map { schemaNameAllowedCharacters.contains($0) ? Character($0) : "_" }
             .map(String.init)
             .joined()
         let truncated = String(cleaned.prefix(64))

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -35,7 +35,7 @@ final public class OpenAI: LangTools {
     public static var requestValidators: [(any LangToolsRequest) -> Bool] {
         return [
             { ($0 as? ChatCompletionRequest).flatMap { OpenAIModel.openAIModels.contains($0.model) } ?? false },
-            { $0 is ResponseRequest },
+            { ($0 as? ResponseRequest).flatMap { $0.model.type == .chat } ?? false },
             { $0 is AudioSpeechRequest },
             { $0 is AudioTranscriptionRequest },
             { $0 is ListModelDataRequest },
@@ -51,8 +51,11 @@ final public class OpenAI: LangTools {
     /// payload yield `nil` and are skipped). All other request types fall back to decoding
     /// the `data:` payload directly as the response type.
     public static func decodeStream<T: Decodable>(_ buffer: String) throws -> T? {
-        guard buffer.hasPrefix("data:"), !buffer.contains("[DONE]"),
-              let data = buffer.dropFirst(5).data(using: .utf8) else { return nil }
+        guard buffer.hasPrefix("data:") else { return nil }
+        // Match the SSE terminator on the exact payload, not a substring, so a delta whose
+        // JSON happens to contain "[DONE]" isn't dropped.
+        let payload = buffer.dropFirst(5).trimmingCharacters(in: .whitespaces)
+        guard payload != "[DONE]", let data = payload.data(using: .utf8) else { return nil }
         if T.self == ResponseResponse.self {
             let event: ResponseStreamEvent = try decodeResponse(data: data)
             return event.partialResponse as? T

--- a/Sources/OpenAI/README.md
+++ b/Sources/OpenAI/README.md
@@ -5,6 +5,7 @@ Swift interface for OpenAI's APIs, part of the LangTools framework.
 ## Features
 
 - 🤖 Chat Completions with GPT models
+- 🧩 Responses API (`/v1/responses`) with streaming, tools & structured output
 - 🗣️ Text-to-Speech and Speech-to-Text
 - 📊 Embeddings generation
 - 🔄 Streaming support
@@ -131,6 +132,74 @@ let request = OpenAI.ChatCompletionRequest(
 
 let response = try await openai.perform(request: request)
 ```
+
+### Responses API
+
+The [Responses API](https://platform.openai.com/docs/api-reference/responses) is
+OpenAI's newer, stateful interface. It models a conversation as an array of input
+items and returns an array of output items (messages, function calls, reasoning).
+`OpenAI.ResponseRequest` bridges this onto the same LangTools engine, so streaming,
+the function-calling loop, and structured output all work the same way they do for
+Chat Completions.
+
+Basic request:
+```swift
+let request = OpenAI.ResponseRequest(
+    model: .gpt4o_mini,
+    messages: [OpenAI.Item(role: .user, content: "Hello!")],
+    instructions: "You are a helpful assistant."
+)
+
+let response = try await openai.perform(request: request)
+print(response.outputText)
+```
+
+Streaming:
+```swift
+let request = OpenAI.ResponseRequest(
+    model: .gpt4o_mini,
+    messages: [OpenAI.Item(role: .user, content: "Write a haiku about Swift.")],
+    stream: true
+)
+
+for try await chunk in openai.stream(request: request) {
+    if let text = chunk.delta?.content { print(text, terminator: "") }
+}
+```
+
+Function calling (automatic tool loop):
+```swift
+let request = OpenAI.ResponseRequest(
+    model: .gpt4o_mini,
+    messages: [OpenAI.Item(role: .user, content: "What's the weather in London?")],
+    tools: [.function(.init(
+        name: "get_weather",
+        description: "Get the current weather",
+        parameters: .init(properties: ["location": .init(type: "string")], required: ["location"]),
+        callback: { _, args in "Sunny in \(args["location"]?.stringValue ?? "")" }))]
+)
+
+let response = try await openai.perform(request: request)
+print(response.outputText)
+```
+
+Hosted tools (`web_search`, `file_search`, `code_interpreter`, …) can be supplied
+alongside function tools, e.g. `tools: [.webSearch]`.
+
+Structured output (the schema is sent as `text.format`):
+```swift
+var request = OpenAI.ResponseRequest(
+    model: .gpt4o_mini,
+    messages: [OpenAI.Item(role: .user, content: "Extract the name and age.")]
+)
+request.responseSchema = JSONSchema.object(
+    properties: ["name": .string(), "age": .integer()],
+    required: ["name", "age"]
+)
+let (response, output) = try await openai.perform(request: request, as: Person.self)
+```
+
+To continue a server-side stored conversation, pass `previous_response_id`.
 
 ### Text-to-Speech
 

--- a/Tests/OpenAITests/ResponseTests.swift
+++ b/Tests/OpenAITests/ResponseTests.swift
@@ -168,11 +168,11 @@ final class ResponseTests: XCTestCase {
         let request = OpenAI.ResponseRequest(
             model: .gpt4o_mini,
             messages: [OpenAI.Item(role: .user, content: "weather?")],
-            stream: true,
             tools: [.function(.init(
                 name: "getCurrentWeather",
                 description: "Get the current weather",
-                parameters: .init(properties: ["location": .init(type: "string")], required: ["location"])))])
+                parameters: .init(properties: ["location": .init(type: "string")], required: ["location"])))],
+            stream: true)
 
         var combined = OpenAI.ResponseResponse.empty
         for try await response in api.stream(request: request) {
@@ -204,8 +204,8 @@ final class ResponseTests: XCTestCase {
         let request = OpenAI.ResponseRequest(
             model: .gpt4o_mini,
             messages: [OpenAI.Item(role: .user, content: "weather?")],
-            stream: true,
-            tools: tools)
+            tools: tools,
+            stream: true)
 
         var results: [OpenAI.ResponseResponse] = []
         for try await response in api.stream(request: request) {

--- a/Tests/OpenAITests/ResponseTests.swift
+++ b/Tests/OpenAITests/ResponseTests.swift
@@ -88,6 +88,20 @@ final class ResponseTests: XCTestCase {
         XCTAssertEqual(input[2]["output"] as? String, "sunny")
     }
 
+    func testHostedToolChoiceEncoding() throws {
+        let choice = OpenAI.ResponseRequest.ToolChoice.hostedTool("file_search")
+        let json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(choice)) as! [String: Any]
+        XCTAssertEqual(json["type"] as? String, "file_search")
+        XCTAssertNil(json["name"])
+
+        let decoded = try JSONDecoder().decode(OpenAI.ResponseRequest.ToolChoice.self, from: "{\"type\":\"web_search\"}".data(using: .utf8)!)
+        if case .hostedTool(let type) = decoded {
+            XCTAssertEqual(type, "web_search")
+        } else {
+            XCTFail("Expected .hostedTool, got \(decoded)")
+        }
+    }
+
     func testInitPreservesTextAndToolCallsFromMixedMessage() throws {
         let source = try OpenAI.Message(
             role: .assistant,

--- a/Tests/OpenAITests/ResponseTests.swift
+++ b/Tests/OpenAITests/ResponseTests.swift
@@ -191,6 +191,23 @@ final class ResponseTests: XCTestCase {
         XCTAssertEqual(results.last?.status, "completed")
     }
 
+    func testFailedResponseStreamSurfacesError() async throws {
+        // The `response.failed` payload omits `output`, exercising the tolerant decode.
+        MockURLProtocol.mockNetworkHandlers[OpenAI.ResponseRequest.endpoint] = { _ in
+            return (.success(try self.getData(filename: "response_failed_stream", fileExtension: "txt")!), 200)
+        }
+        var combined = OpenAI.ResponseResponse.empty
+        for try await response in api.stream(request: OpenAI.ResponseRequest(
+            model: .gpt4o_mini,
+            messages: [OpenAI.Item(role: .user, content: "Hi")],
+            stream: true)) {
+            combined = combined.combining(with: response)
+        }
+        XCTAssertEqual(combined.status, "failed")
+        XCTAssertEqual(combined.error?.code, "server_error")
+        XCTAssertEqual(combined.error?.message, "boom")
+    }
+
     func testToolCallStream() async throws {
         MockURLProtocol.mockNetworkHandlers[OpenAI.ResponseRequest.endpoint] = { _ in
             return (.success(try self.getData(filename: "response_tool_call_stream", fileExtension: "txt")!), 200)

--- a/Tests/OpenAITests/ResponseTests.swift
+++ b/Tests/OpenAITests/ResponseTests.swift
@@ -99,6 +99,14 @@ final class ResponseTests: XCTestCase {
         XCTAssertEqual(item.tool_calls?.first?.name, "lookup")
     }
 
+    func testEncodingItemWithTextAndToolCallDirectlyThrows() throws {
+        let mixed = OpenAI.Item(
+            role: .assistant,
+            content: .string("text"),
+            tool_calls: [.init(index: 0, id: "c1", type: .function, function: .init(name: "f", arguments: "{}"))])
+        XCTAssertThrowsError(try JSONEncoder().encode(mixed))
+    }
+
     func testAssistantTextAndToolCallsFlattenedToInputItems() throws {
         let assistant = OpenAI.Item(
             role: .assistant,

--- a/Tests/OpenAITests/ResponseTests.swift
+++ b/Tests/OpenAITests/ResponseTests.swift
@@ -88,6 +88,36 @@ final class ResponseTests: XCTestCase {
         XCTAssertEqual(input[2]["output"] as? String, "sunny")
     }
 
+    func testInitPreservesTextAndToolCallsFromMixedMessage() throws {
+        let source = try OpenAI.Message(
+            role: .assistant,
+            content: .string("Checking now."),
+            tool_calls: [.init(index: 0, id: "call_7", type: .function, function: .init(name: "lookup", arguments: "{}"))])
+        let item = OpenAI.Item(source)
+        XCTAssertEqual(item.content.string, "Checking now.")
+        XCTAssertEqual(item.tool_calls?.first?.id, "call_7")
+        XCTAssertEqual(item.tool_calls?.first?.name, "lookup")
+    }
+
+    func testAssistantTextAndToolCallsFlattenedToInputItems() throws {
+        let assistant = OpenAI.Item(
+            role: .assistant,
+            content: .string("Let me check the weather."),
+            tool_calls: [.init(index: 0, id: "call_3", type: .function, function: .init(name: "getWeather", arguments: "{}"))])
+        let request = OpenAI.ResponseRequest(
+            model: .gpt4o_mini,
+            messages: [.init(role: .user, content: "weather?"), assistant])
+
+        let json = try JSONSerialization.jsonObject(with: request.data()) as! [String: Any]
+        let input = json["input"] as! [[String: Any]]
+        // user message, assistant text message, function_call
+        XCTAssertEqual(input.count, 3)
+        XCTAssertEqual(input[1]["role"] as? String, "assistant")
+        XCTAssertEqual(input[1]["content"] as? String, "Let me check the weather.")
+        XCTAssertEqual(input[2]["type"] as? String, "function_call")
+        XCTAssertEqual(input[2]["name"] as? String, "getWeather")
+    }
+
     func testStructuredOutputEncoding() throws {
         var request = OpenAI.ResponseRequest(model: .gpt4o_mini, messages: [.init(role: .user, content: "Hi")])
         request.responseSchema = JSONSchema.object(

--- a/Tests/OpenAITests/ResponseTests.swift
+++ b/Tests/OpenAITests/ResponseTests.swift
@@ -70,7 +70,7 @@ final class ResponseTests: XCTestCase {
         let toolResult = OpenAI.Item(tool_selection_id: "call_9", result: "sunny")
         let request = OpenAI.ResponseRequest(
             model: .gpt4o_mini,
-            messages: [OpenAI.Item(role: .user, content: "weather?"), assistant, toolResult])
+            messages: [.init(role: .user, content: "weather?"), assistant, toolResult])
 
         let json = try JSONSerialization.jsonObject(with: request.data()) as! [String: Any]
         let input = json["input"] as! [[String: Any]]
@@ -89,7 +89,7 @@ final class ResponseTests: XCTestCase {
     }
 
     func testStructuredOutputEncoding() throws {
-        var request = OpenAI.ResponseRequest(model: .gpt4o_mini, messages: [OpenAI.Item(role: .user, content: "Hi")])
+        var request = OpenAI.ResponseRequest(model: .gpt4o_mini, messages: [.init(role: .user, content: "Hi")])
         request.responseSchema = JSONSchema.object(
             properties: ["name": .string(), "age": .integer()],
             required: ["name", "age"],
@@ -137,7 +137,7 @@ final class ResponseTests: XCTestCase {
         }
         let response = try await api.perform(request: OpenAI.ResponseRequest(
             model: .gpt4o_mini,
-            messages: [OpenAI.Item(role: .user, content: "Hi")]))
+            messages: [.init(role: .user, content: "Hi")]))
         XCTAssertEqual(response.outputText, "Hello there! How can I help you today?")
         XCTAssertEqual(response.usage?.total_tokens, 19)
     }

--- a/Tests/OpenAITests/ResponseTests.swift
+++ b/Tests/OpenAITests/ResponseTests.swift
@@ -1,0 +1,217 @@
+//
+//  ResponseTests.swift
+//  OpenAITests
+//
+//  Tests for the OpenAI Responses API.
+//
+
+import XCTest
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import TestUtils
+@testable import OpenAI
+@testable import LangTools
+
+final class ResponseTests: XCTestCase {
+
+    var api: OpenAI!
+
+    override func setUp() {
+        super.setUp()
+        URLProtocol.registerClass(MockURLProtocol.self)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        api = OpenAI(apiKey: "").configure(testURLSessionConfiguration: config)
+    }
+
+    override func tearDown() {
+        MockURLProtocol.mockNetworkHandlers.removeAll()
+        URLProtocol.unregisterClass(MockURLProtocol.self)
+        super.tearDown()
+    }
+
+    // MARK: - Encoding
+
+    func testRequestEncoding() throws {
+        let request = OpenAI.ResponseRequest(
+            model: .gpt4o_mini,
+            messages: [OpenAI.Item(role: .user, content: "Hi")],
+            instructions: "Be nice",
+            tools: [.function(.init(
+                name: "getWeather",
+                description: "Get the weather",
+                parameters: .init(properties: ["location": .init(type: "string")], required: ["location"])))],
+            temperature: 0.5,
+            max_output_tokens: 256)
+
+        let json = try JSONSerialization.jsonObject(with: request.data()) as! [String: Any]
+        XCTAssertEqual(json["model"] as? String, "gpt-4o-mini")
+        XCTAssertEqual(json["instructions"] as? String, "Be nice")
+        XCTAssertEqual(json["temperature"] as? Double, 0.5)
+        XCTAssertEqual(json["max_output_tokens"] as? Int, 256)
+
+        let input = json["input"] as! [[String: Any]]
+        XCTAssertEqual(input.count, 1)
+        XCTAssertEqual(input[0]["role"] as? String, "user")
+        XCTAssertEqual(input[0]["content"] as? String, "Hi")
+
+        let tools = json["tools"] as! [[String: Any]]
+        XCTAssertEqual(tools[0]["type"] as? String, "function")
+        XCTAssertEqual(tools[0]["name"] as? String, "getWeather")
+        XCTAssertEqual(tools[0]["description"] as? String, "Get the weather")
+        XCTAssertNotNil(tools[0]["parameters"])
+    }
+
+    func testToolCallAndResultFlattenedToInputItems() throws {
+        let assistant = OpenAI.Item(tool_selection: [
+            .init(index: 0, id: "call_9", type: .function, function: .init(name: "getWeather", arguments: "{\"location\":\"NYC\"}"))
+        ])
+        let toolResult = OpenAI.Item(tool_selection_id: "call_9", result: "sunny")
+        let request = OpenAI.ResponseRequest(
+            model: .gpt4o_mini,
+            messages: [OpenAI.Item(role: .user, content: "weather?"), assistant, toolResult])
+
+        let json = try JSONSerialization.jsonObject(with: request.data()) as! [String: Any]
+        let input = json["input"] as! [[String: Any]]
+        XCTAssertEqual(input.count, 3)
+
+        XCTAssertEqual(input[0]["role"] as? String, "user")
+
+        XCTAssertEqual(input[1]["type"] as? String, "function_call")
+        XCTAssertEqual(input[1]["call_id"] as? String, "call_9")
+        XCTAssertEqual(input[1]["name"] as? String, "getWeather")
+        XCTAssertEqual(input[1]["arguments"] as? String, "{\"location\":\"NYC\"}")
+
+        XCTAssertEqual(input[2]["type"] as? String, "function_call_output")
+        XCTAssertEqual(input[2]["call_id"] as? String, "call_9")
+        XCTAssertEqual(input[2]["output"] as? String, "sunny")
+    }
+
+    func testStructuredOutputEncoding() throws {
+        var request = OpenAI.ResponseRequest(model: .gpt4o_mini, messages: [OpenAI.Item(role: .user, content: "Hi")])
+        request.responseSchema = JSONSchema.object(
+            properties: ["name": .string(), "age": .integer()],
+            required: ["name", "age"],
+            additionalProperties: .bool(false))
+
+        XCTAssertTrue(request.usesStructuredOutput)
+
+        let json = try JSONSerialization.jsonObject(with: request.data()) as! [String: Any]
+        let text = json["text"] as! [String: Any]
+        let format = text["format"] as! [String: Any]
+        XCTAssertEqual(format["type"] as? String, "json_schema")
+        XCTAssertEqual(format["strict"] as? Bool, true)
+        XCTAssertNotNil(format["name"])
+        XCTAssertNotNil(format["schema"])
+    }
+
+    func testReasoningEncoding() throws {
+        let request = OpenAI.ResponseRequest(
+            model: .o4_mini,
+            messages: [OpenAI.Item(role: .user, content: "Think")],
+            reasoning: .init(effort: .high, summary: .auto))
+        let json = try JSONSerialization.jsonObject(with: request.data()) as! [String: Any]
+        let reasoning = json["reasoning"] as! [String: Any]
+        XCTAssertEqual(reasoning["effort"] as? String, "high")
+        XCTAssertEqual(reasoning["summary"] as? String, "auto")
+    }
+
+    // MARK: - Response decoding
+
+    func testResponseDecoding() throws {
+        let data = try getData(filename: "response_create")!
+        let response: OpenAI.ResponseResponse = try OpenAI.decodeResponse(data: data)
+        XCTAssertEqual(response.id, "resp_abc123")
+        XCTAssertEqual(response.status, "completed")
+        XCTAssertEqual(response.outputText, "Hello there! How can I help you today?")
+        XCTAssertEqual(response.message?.content.text, "Hello there! How can I help you today?")
+        XCTAssertEqual(response.usage?.total_tokens, 19)
+        XCTAssertEqual(response.usage?.input_tokens, 8)
+        XCTAssertEqual(response.usage?.output_tokens, 11)
+    }
+
+    func testPerformResponse() async throws {
+        MockURLProtocol.mockNetworkHandlers[OpenAI.ResponseRequest.endpoint] = { _ in
+            return (.success(try self.getData(filename: "response_create")!), 200)
+        }
+        let response = try await api.perform(request: OpenAI.ResponseRequest(
+            model: .gpt4o_mini,
+            messages: [OpenAI.Item(role: .user, content: "Hi")]))
+        XCTAssertEqual(response.outputText, "Hello there! How can I help you today?")
+        XCTAssertEqual(response.usage?.total_tokens, 19)
+    }
+
+    // MARK: - Streaming
+
+    func testResponseStream() async throws {
+        MockURLProtocol.mockNetworkHandlers[OpenAI.ResponseRequest.endpoint] = { _ in
+            return (.success(try self.getData(filename: "response_stream", fileExtension: "txt")!), 200)
+        }
+        var results: [OpenAI.ResponseResponse] = []
+        for try await response in api.stream(request: OpenAI.ResponseRequest(
+            model: .gpt4o_mini,
+            messages: [OpenAI.Item(role: .user, content: "Hi")],
+            stream: true)) {
+            results.append(response)
+        }
+        let text = results.reduce("") { $0 + ($1.delta?.content ?? "") }
+        XCTAssertEqual(text, "Hello, world!")
+        XCTAssertEqual(results.last?.usage?.total_tokens, 15)
+        XCTAssertEqual(results.last?.status, "completed")
+    }
+
+    func testToolCallStream() async throws {
+        MockURLProtocol.mockNetworkHandlers[OpenAI.ResponseRequest.endpoint] = { _ in
+            return (.success(try self.getData(filename: "response_tool_call_stream", fileExtension: "txt")!), 200)
+        }
+        let request = OpenAI.ResponseRequest(
+            model: .gpt4o_mini,
+            messages: [OpenAI.Item(role: .user, content: "weather?")],
+            stream: true,
+            tools: [.function(.init(
+                name: "getCurrentWeather",
+                description: "Get the current weather",
+                parameters: .init(properties: ["location": .init(type: "string")], required: ["location"])))])
+
+        var combined = OpenAI.ResponseResponse.empty
+        for try await response in api.stream(request: request) {
+            combined = combined.combining(with: response)
+        }
+
+        let call = combined.message?.tool_selection?.first
+        XCTAssertEqual(call?.name, "getCurrentWeather")
+        XCTAssertEqual(call?.id, "call_1")
+        XCTAssertEqual(call?.arguments, "{\"location\":\"Bangkok\"}")
+    }
+
+    func testToolCallWithCallbackStream() async throws {
+        let tools: [OpenAI.ResponseRequest.Tool] = [.function(.init(
+            name: "getCurrentWeather",
+            description: "Get the current weather",
+            parameters: .init(properties: ["location": .init(type: "string")], required: ["location"]),
+            callback: { _, _ in
+                MockURLProtocol.mockNetworkHandlers[OpenAI.ResponseRequest.endpoint] = { _ in
+                    return (.success(try self.getData(filename: "response_tool_call_stream_response", fileExtension: "txt")!), 200)
+                }
+                return "27"
+            }))]
+
+        MockURLProtocol.mockNetworkHandlers[OpenAI.ResponseRequest.endpoint] = { _ in
+            return (.success(try self.getData(filename: "response_tool_call_stream", fileExtension: "txt")!), 200)
+        }
+
+        let request = OpenAI.ResponseRequest(
+            model: .gpt4o_mini,
+            messages: [OpenAI.Item(role: .user, content: "weather?")],
+            stream: true,
+            tools: tools)
+
+        var results: [OpenAI.ResponseResponse] = []
+        for try await response in api.stream(request: request) {
+            results.append(response)
+        }
+        let text = results.reduce("") { $0 + ($1.delta?.content ?? "") }
+        XCTAssertEqual(text, "It's 27°C in Bangkok.")
+    }
+}

--- a/Tests/TestUtils/Resources/response_create.json
+++ b/Tests/TestUtils/Resources/response_create.json
@@ -1,0 +1,29 @@
+{
+  "id": "resp_abc123",
+  "object": "response",
+  "created_at": 1741476542,
+  "status": "completed",
+  "model": "gpt-4o-mini",
+  "output": [
+    {
+      "type": "message",
+      "id": "msg_abc123",
+      "status": "completed",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "Hello there! How can I help you today?",
+          "annotations": []
+        }
+      ]
+    }
+  ],
+  "usage": {
+    "input_tokens": 8,
+    "input_tokens_details": { "cached_tokens": 0 },
+    "output_tokens": 11,
+    "output_tokens_details": { "reasoning_tokens": 0 },
+    "total_tokens": 19
+  }
+}

--- a/Tests/TestUtils/Resources/response_failed_stream.txt
+++ b/Tests/TestUtils/Resources/response_failed_stream.txt
@@ -1,0 +1,6 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_f","object":"response","created_at":9,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
+
+event: response.failed
+data: {"type":"response.failed","response":{"id":"resp_f","object":"response","created_at":9,"status":"failed","model":"gpt-4o-mini","error":{"code":"server_error","message":"boom"}}}
+

--- a/Tests/TestUtils/Resources/response_stream.txt
+++ b/Tests/TestUtils/Resources/response_stream.txt
@@ -1,0 +1,27 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_1","object":"response","created_at":1,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
+
+event: response.in_progress
+data: {"type":"response.in_progress","response":{"id":"resp_1","object":"response","created_at":1,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_1","status":"in_progress","role":"assistant","content":[]}}
+
+event: response.content_part.added
+data: {"type":"response.content_part.added","item_id":"msg_1","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":"Hello"}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":0,"content_index":0,"delta":", world!"}
+
+event: response.output_text.done
+data: {"type":"response.output_text.done","item_id":"msg_1","output_index":0,"content_index":0,"text":"Hello, world!"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_1","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello, world!","annotations":[]}]}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":1,"status":"completed","model":"gpt-4o-mini","output":[{"type":"message","id":"msg_1","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hello, world!","annotations":[]}]}],"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":15}}}
+

--- a/Tests/TestUtils/Resources/response_tool_call_stream.txt
+++ b/Tests/TestUtils/Resources/response_tool_call_stream.txt
@@ -1,0 +1,21 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_2","object":"response","created_at":2,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"getCurrentWeather","arguments":""}}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"{\"location\":"}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"\"Bangkok\"}"}
+
+event: response.function_call_arguments.done
+data: {"type":"response.function_call_arguments.done","item_id":"fc_1","output_index":0,"arguments":"{\"location\":\"Bangkok\"}"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"getCurrentWeather","arguments":"{\"location\":\"Bangkok\"}","status":"completed"}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_2","object":"response","created_at":2,"status":"completed","model":"gpt-4o-mini","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"getCurrentWeather","arguments":"{\"location\":\"Bangkok\"}","status":"completed"}],"usage":{"input_tokens":20,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":30}}}
+

--- a/Tests/TestUtils/Resources/response_tool_call_stream_response.txt
+++ b/Tests/TestUtils/Resources/response_tool_call_stream_response.txt
@@ -1,0 +1,15 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_3","object":"response","created_at":3,"status":"in_progress","model":"gpt-4o-mini","output":[]}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_2","status":"in_progress","role":"assistant","content":[]}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_2","output_index":0,"content_index":0,"delta":"It's 27"}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_2","output_index":0,"content_index":0,"delta":"°C in Bangkok."}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_3","object":"response","created_at":3,"status":"completed","model":"gpt-4o-mini","output":[{"type":"message","id":"msg_2","status":"completed","role":"assistant","content":[{"type":"output_text","text":"It's 27°C in Bangkok.","annotations":[]}]}],"usage":{"input_tokens":40,"input_tokens_details":{"cached_tokens":0},"output_tokens":12,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":52}}}
+


### PR DESCRIPTION
## Summary

Adds support for the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses) (`POST /v1/responses`) as a first-class LangTools request type.

The Responses API models a conversation as an array of **input items** and returns an array of **output items** (messages, function calls, reasoning) rather than chat-style `messages`/`choices`. This PR bridges that shape onto the existing LangTools chat / tool-calling / streaming / structured-output protocols, so the shared engine (automatic tool loop, streaming accumulation, `perform(request:as:)`) works without modification.

## What's added

- **`OpenAI.ResponseRequest`** — `model`, input items, `instructions`, sampling/limit options, `tool_choice`, `reasoning` (`effort`/`summary`), structured output via `text.format`, `previous_response_id`, `store`, `metadata`, `include`, etc. Custom encoding flattens assistant tool calls and tool results into `function_call` / `function_call_output` input items on the wire.
- **`OpenAI.ResponseRequest.Tool`** — function tools (callback-driven, drive the tool loop) plus hosted tools: `.webSearch`, `.webSearchPreview`, `.fileSearch(vectorStoreIDs:)`, `.codeInterpreter`, `.imageGeneration`.
- **`OpenAI.ResponseResponse`** — decodes the output-item array, synthesises the assistant message (concatenated text + tool calls), and exposes `outputText` / `usage` / `status`. Conforms to the streamable / tool-calling / structured-output response protocols.
- **`OpenAI.Item`** — the shared conversation item, reusing the existing `OpenAI.Message` value types (`Role`, `Content`, `ToolCall`, `ToolResultContent`) for cross-provider conversion.
- **Streaming** — `OpenAI.decodeStream` maps semantic SSE events (`response.output_text.delta`, `response.function_call_arguments.delta`, `response.output_item.added`, `response.completed`, …) onto partial responses that accumulate via `combining(with:)`. Chat Completions streaming is unaffected (the override delegates to the existing decode for non-Responses requests).
- Registers the request validator, adds a Responses API section to the OpenAI README, and adds tests.

## Usage

```swift
let response = try await openai.perform(request: OpenAI.ResponseRequest(
    model: .gpt4o_mini,
    messages: [OpenAI.Item(role: .user, content: "Hello!")],
    instructions: "You are a helpful assistant."
))
print(response.outputText)
```

## Tests

`Tests/OpenAITests/ResponseTests.swift` covers request encoding (incl. tool-call/result flattening), structured-output and reasoning encoding, response decoding, `perform`, text streaming, tool-call stream accumulation, and the full automatic tool-call loop with a callback. New fixtures live under `Tests/TestUtils/Resources/`.

> [!NOTE]
> The Swift toolchain / Docker registry were not reachable in the authoring environment, so the build was not run locally — CI is the validation gate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3RdS9JrdfGTQ9k1tvEmfN)_