### PR TITLE
fix: address post-merge review findings from PR #34

### DIFF
--- a/Examples/LangTools_Example/Modules/Audio/STTService.swift
+++ b/Examples/LangTools_Example/Modules/Audio/STTService.swift
@@ -350,6 +350,8 @@ public class STTService: ObservableObject {
         case .recognitionFailed(let message):
             error = .transcriptionFailed(message)
             status = .error(message)
+            isRecording = false
+            isProcessing = false
         case .autoDetectLanguageSwitch:
             break
         }
@@ -378,7 +380,15 @@ public class STTService: ObservableObject {
         }
 
         if let finalAudioData, finalAudioData.count > lastChunkSize {
-            try? await provider.appendStreamingAudio(finalAudioData)
+            do {
+                try await provider.appendStreamingAudio(finalAudioData)
+            } catch {
+                print("[STTService] Final audio chunk append failed: \(error)")
+                self.error = error as? STTError ?? .transcriptionFailed(error.localizedDescription)
+                status = .error(error.localizedDescription)
+                isProcessing = false
+                return nil
+            }
         }
 
         let finalText = await provider.stopStreamingRecognition()

--- a/Examples/LangTools_Example/Modules/Audio/STTService.swift
+++ b/Examples/LangTools_Example/Modules/Audio/STTService.swift
@@ -380,9 +380,9 @@ public class STTService: ObservableObject {
         if let finalAudioData, finalAudioData.count > lastChunkSize {
             do {
                 try await provider.appendStreamingAudio(finalAudioData)
-            } catch {
-                _ = await provider.stopStreamingRecognition()
-                print("[STTService] Final audio chunk append failed: \(error)")
+} catch {
+    provider.stopRecognition(finalizePending: false, clearTranscript: false)
+    print("[STTService] Final audio chunk append failed: \(error)")
                 self.error = error as? STTError ?? .transcriptionFailed(error.localizedDescription)
                 status = .error(error.localizedDescription)
                 isProcessing = false

--- a/Examples/LangTools_Example/Modules/Audio/STTService.swift
+++ b/Examples/LangTools_Example/Modules/Audio/STTService.swift
@@ -383,6 +383,7 @@ public class STTService: ObservableObject {
             do {
                 try await provider.appendStreamingAudio(finalAudioData)
             } catch {
+                _ = await provider.stopStreamingRecognition()
                 print("[STTService] Final audio chunk append failed: \(error)")
                 self.error = error as? STTError ?? .transcriptionFailed(error.localizedDescription)
                 status = .error(error.localizedDescription)

--- a/Examples/LangTools_Example/Modules/Audio/STTService.swift
+++ b/Examples/LangTools_Example/Modules/Audio/STTService.swift
@@ -352,8 +352,6 @@ public class STTService: ObservableObject {
             status = .error(message)
             isRecording = false
             isProcessing = false
-        case .autoDetectLanguageSwitch:
-            break
         }
     }
 

--- a/Examples/LangTools_Example/Modules/Audio/STTService.swift
+++ b/Examples/LangTools_Example/Modules/Audio/STTService.swift
@@ -380,9 +380,9 @@ public class STTService: ObservableObject {
         if let finalAudioData, finalAudioData.count > lastChunkSize {
             do {
                 try await provider.appendStreamingAudio(finalAudioData)
-} catch {
-    provider.stopRecognition(finalizePending: false, clearTranscript: false)
-    print("[STTService] Final audio chunk append failed: \(error)")
+            } catch {
+                provider.stopRecognition(finalizePending: false, clearTranscript: false)
+                print("[STTService] Final audio chunk append failed: \(error)")
                 self.error = error as? STTError ?? .transcriptionFailed(error.localizedDescription)
                 status = .error(error.localizedDescription)
                 isProcessing = false

--- a/Sources/Apple/AppleSpeechRecognitionProvider.swift
+++ b/Sources/Apple/AppleSpeechRecognitionProvider.swift
@@ -189,9 +189,11 @@ public final class AppleSpeechRecognitionProvider: StreamingSpeechRecognitionPro
             if let error {
                 Task { @MainActor [weak self] in
                     guard let self, self.recognitionSessionID == sessionID else { return }
+                    let transcript = result?.bestTranscription.formattedString ?? self.currentTranscript
+                    self.currentTranscript = transcript
                     if isBenignAppleSpeechTerminalError(error) {
-                        self.eventHandler?(.finalTranscription(self.currentTranscript))
-                        self.onFinalResultCallback?(self.currentTranscript)
+                        self.eventHandler?(.finalTranscription(transcript))
+                        self.onFinalResultCallback?(transcript)
                     } else {
                         self.eventHandler?(.recognitionFailed(error.localizedDescription))
                     }

--- a/Sources/Apple/AppleSpeechRecognitionProvider.swift
+++ b/Sources/Apple/AppleSpeechRecognitionProvider.swift
@@ -3,6 +3,11 @@ import Foundation
 import LangTools
 import Speech
 
+func isBenignAppleSpeechTerminalError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    return nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 1110
+}
+
 private extension SFSpeechRecognizerAuthorizationStatus {
     var providerAuthorizationState: ProviderAuthorizationState {
         switch self {
@@ -184,7 +189,12 @@ public final class AppleSpeechRecognitionProvider: StreamingSpeechRecognitionPro
             if let error {
                 Task { @MainActor [weak self] in
                     guard let self, self.recognitionSessionID == sessionID else { return }
-                    self.eventHandler?(.recognitionFailed(error.localizedDescription))
+                    if isBenignAppleSpeechTerminalError(error) {
+                        self.eventHandler?(.finalTranscription(self.currentTranscript))
+                        self.onFinalResultCallback?(self.currentTranscript)
+                    } else {
+                        self.eventHandler?(.recognitionFailed(error.localizedDescription))
+                    }
                     self.cleanupStreaming()
                 }
                 return

--- a/Sources/Apple/AppleSpeechRecognitionProvider.swift
+++ b/Sources/Apple/AppleSpeechRecognitionProvider.swift
@@ -186,9 +186,10 @@ public final class AppleSpeechRecognitionProvider: StreamingSpeechRecognitionPro
         recognitionSessionID = sessionID
 
         recognitionTask = recognizer.recognitionTask(with: recognitionRequest) { [weak self] result, error in
-            if error != nil {
+            if let error {
                 Task { @MainActor [weak self] in
                     guard let self, self.recognitionSessionID == sessionID else { return }
+                    self.eventHandler?(.recognitionFailed(error.localizedDescription))
                     self.cleanupStreaming()
                 }
                 return

--- a/Sources/LangTools/LangTools+Speech.swift
+++ b/Sources/LangTools/LangTools+Speech.swift
@@ -5,10 +5,13 @@ import Foundation
 /// Provider-neutral response for requests that return synthesized audio.
 public protocol LangToolsAudioResponse {
     var audioData: Data { get }
+    /// Initialize from raw audio bytes returned by the network layer.
+    init(audioData: Data) throws
 }
 
-extension Data: LangToolsAudioResponse {
+extension Data: @retroactive LangToolsAudioResponse {
     public var audioData: Data { self }
+    public init(audioData: Data) throws { self = audioData }
 }
 
 /// Provider-neutral response for requests that return transcribed text.
@@ -17,7 +20,7 @@ public protocol LangToolsTranscriptionResponse {
     var detectedLanguageIdentifier: String? { get }
 }
 
-extension String: LangToolsTranscriptionResponse {
+extension String: @retroactive LangToolsTranscriptionResponse {
     public var transcriptText: String { self }
     public var detectedLanguageIdentifier: String? { nil }
 }

--- a/Sources/LangTools/LangTools+Speech.swift
+++ b/Sources/LangTools/LangTools+Speech.swift
@@ -9,7 +9,7 @@ public protocol LangToolsAudioResponse {
     init(audioData: Data) throws
 }
 
-extension Data: @retroactive LangToolsAudioResponse {
+extension Data: LangToolsAudioResponse {
     public var audioData: Data { self }
     public init(audioData: Data) throws { self = audioData }
 }
@@ -20,7 +20,7 @@ public protocol LangToolsTranscriptionResponse {
     var detectedLanguageIdentifier: String? { get }
 }
 
-extension String: @retroactive LangToolsTranscriptionResponse {
+extension String: LangToolsTranscriptionResponse {
     public var transcriptText: String { self }
     public var detectedLanguageIdentifier: String? { nil }
 }

--- a/Sources/LangTools/LangTools.swift
+++ b/Sources/LangTools/LangTools.swift
@@ -49,9 +49,6 @@ extension LangTools {
         let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else { throw LangToolsError.requestFailed }
         guard httpResponse.statusCode == 200 else { throw LangToolsError.responseUnsuccessful(statusCode: httpResponse.statusCode, Self.decodeError(data: data)) }
-        if let audioResponseType = Response.self as? any LangToolsAudioResponse.Type {
-            return try audioResponseType.init(audioData: data) as! Response
-        }
         return try Self.decodeResponse(data: data)
     }
 
@@ -238,7 +235,7 @@ public enum LangToolsError: Error, LocalizedError {
 public extension LangTools {
     static func decode<Response: Decodable>(completion: @escaping (Result<Response, Error>) -> Void) -> (Data) -> Void { return { completion(decode(data: $0)) }}
     static func decode<Response: Decodable>(data: Data) -> Result<Response, Error> { let d = JSONDecoder(); do { return .success(try decodeResponse(data: data, decoder: d)) } catch { return .failure(error) }}
-    static func decodeResponse<Response: Decodable>(data: Data, decoder: JSONDecoder = JSONDecoder()) throws -> Response { do { return try decoder.decode(Response.self, from: data) } catch { throw decodeError(data: data, decoder: decoder) ?? LangToolsError.jsonParsingFailure(error) }}
+    static func decodeResponse<Response: Decodable>(data: Data, decoder: JSONDecoder = JSONDecoder()) throws -> Response { if let audioResponseType = Response.self as? any LangToolsAudioResponse.Type { return try audioResponseType.init(audioData: data) as! Response }; do { return try decoder.decode(Response.self, from: data) } catch { throw decodeError(data: data, decoder: decoder) ?? LangToolsError.jsonParsingFailure(error) }}
     static func decodeError(data: Data, decoder: JSONDecoder = JSONDecoder()) -> ErrorResponse? { return (try? decoder.decode(ErrorResponse.self, from: data)) }
 }
 

--- a/Sources/LangTools/LangTools.swift
+++ b/Sources/LangTools/LangTools.swift
@@ -49,11 +49,7 @@ extension LangTools {
         let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else { throw LangToolsError.requestFailed }
         guard httpResponse.statusCode == 200 else { throw LangToolsError.responseUnsuccessful(statusCode: httpResponse.statusCode, Self.decodeError(data: data)) }
-        if let audioType = Response.self as? any LangToolsAudioResponse.Type,
-           let result = try audioType.init(audioData: data) as? Response {
-            return result
-        }
-        return try Self.decodeResponse(data: data)
+        return Response.self == Data.self ? data as! Response : try Self.decodeResponse(data: data)
     }
 
     public func stream<Request: LangToolsStreamableRequest>(request: Request) -> AsyncThrowingStream<Request.Response, Error> {

--- a/Sources/LangTools/LangTools.swift
+++ b/Sources/LangTools/LangTools.swift
@@ -49,7 +49,10 @@ extension LangTools {
         let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else { throw LangToolsError.requestFailed }
         guard httpResponse.statusCode == 200 else { throw LangToolsError.responseUnsuccessful(statusCode: httpResponse.statusCode, Self.decodeError(data: data)) }
-        return Response.self == Data.self ? data as! Response : try Self.decodeResponse(data: data)
+        if let audioResponseType = Response.self as? any LangToolsAudioResponse.Type {
+            return try audioResponseType.init(audioData: data) as! Response
+        }
+        return try Self.decodeResponse(data: data)
     }
 
     public func stream<Request: LangToolsStreamableRequest>(request: Request) -> AsyncThrowingStream<Request.Response, Error> {

--- a/Sources/LangTools/LangTools.swift
+++ b/Sources/LangTools/LangTools.swift
@@ -49,7 +49,11 @@ extension LangTools {
         let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else { throw LangToolsError.requestFailed }
         guard httpResponse.statusCode == 200 else { throw LangToolsError.responseUnsuccessful(statusCode: httpResponse.statusCode, Self.decodeError(data: data)) }
-        return Response.self == Data.self ? data as! Response : try Self.decodeResponse(data: data)
+        if let audioType = Response.self as? any LangToolsAudioResponse.Type,
+           let result = try audioType.init(audioData: data) as? Response {
+            return result
+        }
+        return try Self.decodeResponse(data: data)
     }
 
     public func stream<Request: LangToolsStreamableRequest>(request: Request) -> AsyncThrowingStream<Request.Response, Error> {

--- a/Sources/LangTools/LangTools.swift
+++ b/Sources/LangTools/LangTools.swift
@@ -49,7 +49,7 @@ extension LangTools {
         let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else { throw LangToolsError.requestFailed }
         guard httpResponse.statusCode == 200 else { throw LangToolsError.responseUnsuccessful(statusCode: httpResponse.statusCode, Self.decodeError(data: data)) }
-        return try Self.decodeResponse(data: data)
+        if let audioResponseType = Response.self as? any LangToolsAudioResponse.Type { return try audioResponseType.init(audioData: data) as! Response } else { return try Self.decodeResponse(data: data) }
     }
 
     public func stream<Request: LangToolsStreamableRequest>(request: Request) -> AsyncThrowingStream<Request.Response, Error> {
@@ -235,7 +235,7 @@ public enum LangToolsError: Error, LocalizedError {
 public extension LangTools {
     static func decode<Response: Decodable>(completion: @escaping (Result<Response, Error>) -> Void) -> (Data) -> Void { return { completion(decode(data: $0)) }}
     static func decode<Response: Decodable>(data: Data) -> Result<Response, Error> { let d = JSONDecoder(); do { return .success(try decodeResponse(data: data, decoder: d)) } catch { return .failure(error) }}
-    static func decodeResponse<Response: Decodable>(data: Data, decoder: JSONDecoder = JSONDecoder()) throws -> Response { if let audioResponseType = Response.self as? any LangToolsAudioResponse.Type { return try audioResponseType.init(audioData: data) as! Response }; do { return try decoder.decode(Response.self, from: data) } catch { throw decodeError(data: data, decoder: decoder) ?? LangToolsError.jsonParsingFailure(error) }}
+    static func decodeResponse<Response: Decodable>(data: Data, decoder: JSONDecoder = JSONDecoder()) throws -> Response { do { return try decoder.decode(Response.self, from: data) } catch { throw decodeError(data: data, decoder: decoder) ?? LangToolsError.jsonParsingFailure(error) }}
     static func decodeError(data: Data, decoder: JSONDecoder = JSONDecoder()) -> ErrorResponse? { return (try? decoder.decode(ErrorResponse.self, from: data)) }
 }
 

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -285,53 +285,57 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
     }
 
     private func initializeWhisperKit() async throws {
-        let modelVariant = modelVariantProvider()
-        if whisperKit != nil && currentModelVariant != modelVariant {
-            whisperKit = nil
-        }
+        while true {
+            let modelVariant = modelVariantProvider()
+            if whisperKit != nil && currentModelVariant != modelVariant {
+                whisperKit = nil
+            }
 
-        if whisperKit != nil { return }
+            if whisperKit != nil { return }
 
-        if isInitializing {
-            // Await the in-flight initialization rather than returning silently.
-            // This prevents a spurious providerNotConfigured error when transcribe()
-            // races with a concurrent preload().
-            try Task.checkCancellation()
-            try await awaitPendingInitialization()
-            try Task.checkCancellation()
-            return
-        }
+            if isInitializing {
+                // Await the in-flight initialization rather than returning silently.
+                // This prevents a spurious providerNotConfigured error when transcribe()
+                // races with a concurrent preload(). Re-check the requested model after
+                // the wait so a model-selection change does not reuse the wrong variant.
+                try Task.checkCancellation()
+                try await awaitPendingInitialization()
+                try Task.checkCancellation()
+                continue
+            }
 
-        isInitializing = true
-        loadingState = isModelDownloaded(modelVariant) ? .loading : .downloading
-        do {
-            let config = WhisperKitConfig(model: modelVariant, verbose: false, prewarm: false, load: false, download: true)
-            let initializedWhisperKit = try await WhisperKit(config)
-            try Task.checkCancellation()
-            whisperKit = initializedWhisperKit
-            loadingState = .loading
-            try await whisperKit?.loadModels()
-            try Task.checkCancellation()
-            currentModelVariant = modelVariant
-            loadingState = .ready
-            isInitializing = false
-            completePendingInitializationContinuations()
-        } catch is CancellationError {
-            whisperKit = nil
-            currentModelVariant = nil
-            loadingState = .idle
-            isInitializing = false
-            let cancellation = CancellationError()
-            completePendingInitializationContinuations(throwing: cancellation)
-            throw cancellation
-        } catch {
-            whisperKit = nil
-            currentModelVariant = nil
-            loadingState = .failed(error.localizedDescription)
-            isInitializing = false
-            let speechError = WhisperKitLangToolsSpeechError.transcriptionFailed("WhisperKit initialization failed: \(error.localizedDescription)")
-            completePendingInitializationContinuations(throwing: speechError)
-            throw speechError
+            isInitializing = true
+            loadingState = isModelDownloaded(modelVariant) ? .loading : .downloading
+            do {
+                let config = WhisperKitConfig(model: modelVariant, verbose: false, prewarm: false, load: false, download: true)
+                let initializedWhisperKit = try await WhisperKit(config)
+                try Task.checkCancellation()
+                whisperKit = initializedWhisperKit
+                loadingState = .loading
+                try await whisperKit?.loadModels()
+                try Task.checkCancellation()
+                currentModelVariant = modelVariant
+                loadingState = .ready
+                isInitializing = false
+                completePendingInitializationContinuations()
+                return
+            } catch is CancellationError {
+                whisperKit = nil
+                currentModelVariant = nil
+                loadingState = .idle
+                isInitializing = false
+                let cancellation = CancellationError()
+                completePendingInitializationContinuations(throwing: cancellation)
+                throw cancellation
+            } catch {
+                whisperKit = nil
+                currentModelVariant = nil
+                loadingState = .failed(error.localizedDescription)
+                isInitializing = false
+                let speechError = WhisperKitLangToolsSpeechError.transcriptionFailed("WhisperKit initialization failed: \(error.localizedDescription)")
+                completePendingInitializationContinuations(throwing: speechError)
+                throw speechError
+            }
         }
     }
 

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -339,12 +339,18 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
         }
     }
 
+    #if DEBUG
     func test_enqueuePendingInitializationContinuation() async throws {
         try await awaitPendingInitialization()
     }
 
     func test_beginInitialization() {
         isInitializing = true
+    }
+
+    func test_completeInitializationForTesting() {
+        isInitializing = false
+        completePendingInitializationContinuations()
     }
 
     func test_cancelInitializationForTesting() {
@@ -359,6 +365,7 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
     var test_hasPendingInitializationContinuations: Bool {
         !pendingInitializationContinuations.isEmpty
     }
+    #endif
 
     private func awaitPendingInitialization() async throws {
         let continuationID = UUID()

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -55,7 +55,7 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
 
     private var whisperKit: WhisperKit?
     private var isInitializing = false
-    private var pendingInitializationContinuations: [CheckedContinuation<Void, Error>] = []
+    private var pendingInitializationContinuations: [UUID: CheckedContinuation<Void, Error>] = [:]
     private var currentModelVariant: String?
     private var modelVariantProvider: @MainActor () -> String
     private var languageIdentifierProvider: @MainActor () -> String?
@@ -296,9 +296,9 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
             // Await the in-flight initialization rather than returning silently.
             // This prevents a spurious providerNotConfigured error when transcribe()
             // races with a concurrent preload().
-            try await withCheckedThrowingContinuation { continuation in
-                pendingInitializationContinuations.append(continuation)
-            }
+            try Task.checkCancellation()
+            try await awaitPendingInitialization()
+            try Task.checkCancellation()
             return
         }
 
@@ -336,9 +336,7 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
     }
 
     func test_enqueuePendingInitializationContinuation() async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            pendingInitializationContinuations.append(continuation)
-        }
+        try await awaitPendingInitialization()
     }
 
     func test_beginInitialization() {
@@ -354,14 +352,35 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
         isInitializing
     }
 
-    private func completePendingInitializationContinuations(throwing error: Error? = nil) {
-        let waiting = pendingInitializationContinuations
-        pendingInitializationContinuations.removeAll()
-        if let error {
-            waiting.forEach { $0.resume(throwing: error) }
-        } else {
-            waiting.forEach { $0.resume() }
+    var test_hasPendingInitializationContinuations: Bool {
+        !pendingInitializationContinuations.isEmpty
+    }
+
+    private func awaitPendingInitialization() async throws {
+        let continuationID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                pendingInitializationContinuations[continuationID] = continuation
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.completePendingInitializationContinuation(continuationID, throwing: CancellationError())
+            }
         }
+    }
+
+    private func completePendingInitializationContinuation(_ id: UUID, throwing error: Error? = nil) {
+        guard let continuation = pendingInitializationContinuations.removeValue(forKey: id) else { return }
+        if let error {
+            continuation.resume(throwing: error)
+        } else {
+            continuation.resume()
+        }
+    }
+
+    private func completePendingInitializationContinuations(throwing error: Error? = nil) {
+        let continuationIDs = Array(pendingInitializationContinuations.keys)
+        continuationIDs.forEach { completePendingInitializationContinuation($0, throwing: error) }
     }
 
     func stripSpecialTokens(_ text: String) -> String {

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -56,6 +56,7 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
 
     private var whisperKit: WhisperKit?
     private var isInitializing = false
+    private var pendingInitializationContinuations: [CheckedContinuation<Void, Error>] = []
     private var currentModelVariant: String?
     private var modelVariantProvider: @MainActor () -> String
     private var languageIdentifierProvider: @MainActor () -> String?
@@ -266,10 +267,20 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
         if whisperKit != nil && currentModelVariant != modelVariant {
             whisperKit = nil
         }
-        guard !isInitializing else { return }
-        isInitializing = true
-        defer { isInitializing = false }
 
+        if whisperKit != nil { return }
+
+        if isInitializing {
+            // Await the in-flight initialization rather than returning silently.
+            // This prevents a spurious providerNotConfigured error when transcribe()
+            // races with a concurrent preload().
+            try await withCheckedThrowingContinuation { continuation in
+                pendingInitializationContinuations.append(continuation)
+            }
+            return
+        }
+
+        isInitializing = true
         loadingState = isModelDownloaded(modelVariant) ? .loading : .downloading
         do {
             let config = WhisperKitConfig(model: modelVariant, verbose: false, prewarm: true, download: true)
@@ -284,9 +295,18 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
             }
             currentModelVariant = modelVariant
             loadingState = .ready
+            isInitializing = false
+            let waiting = pendingInitializationContinuations
+            pendingInitializationContinuations.removeAll()
+            waiting.forEach { $0.resume() }
         } catch {
             loadingState = .failed(error.localizedDescription)
-            throw WhisperKitLangToolsSpeechError.transcriptionFailed("WhisperKit initialization failed: \(error.localizedDescription)")
+            isInitializing = false
+            let speechError = WhisperKitLangToolsSpeechError.transcriptionFailed("WhisperKit initialization failed: \(error.localizedDescription)")
+            let waiting = pendingInitializationContinuations
+            pendingInitializationContinuations.removeAll()
+            waiting.forEach { $0.resume(throwing: speechError) }
+            throw speechError
         }
     }
 

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -239,6 +239,7 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
         startupTask = nil
         whisperKit = nil
         isInitializing = false
+        completePendingInitializationContinuations(throwing: CancellationError())
         currentModelVariant = nil
         audioStreamTranscriber = nil
         finalTranscriptionContinuation?.resume(returning: currentTranscript)
@@ -314,24 +315,52 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
             currentModelVariant = modelVariant
             loadingState = .ready
             isInitializing = false
-            let waiting = pendingInitializationContinuations
-            pendingInitializationContinuations.removeAll()
-            waiting.forEach { $0.resume() }
+            completePendingInitializationContinuations()
         } catch is CancellationError {
             whisperKit = nil
             currentModelVariant = nil
             loadingState = .idle
-            throw CancellationError()
+            isInitializing = false
+            let cancellation = CancellationError()
+            completePendingInitializationContinuations(throwing: cancellation)
+            throw cancellation
         } catch {
             whisperKit = nil
             currentModelVariant = nil
             loadingState = .failed(error.localizedDescription)
             isInitializing = false
             let speechError = WhisperKitLangToolsSpeechError.transcriptionFailed("WhisperKit initialization failed: \(error.localizedDescription)")
-            let waiting = pendingInitializationContinuations
-            pendingInitializationContinuations.removeAll()
-            waiting.forEach { $0.resume(throwing: speechError) }
+            completePendingInitializationContinuations(throwing: speechError)
             throw speechError
+        }
+    }
+
+    func test_enqueuePendingInitializationContinuation() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            pendingInitializationContinuations.append(continuation)
+        }
+    }
+
+    func test_beginInitialization() {
+        isInitializing = true
+    }
+
+    func test_cancelInitializationForTesting() {
+        isInitializing = false
+        completePendingInitializationContinuations(throwing: CancellationError())
+    }
+
+    var test_isInitializing: Bool {
+        isInitializing
+    }
+
+    private func completePendingInitializationContinuations(throwing error: Error? = nil) {
+        let waiting = pendingInitializationContinuations
+        pendingInitializationContinuations.removeAll()
+        if let error {
+            waiting.forEach { $0.resume(throwing: error) }
+        } else {
+            waiting.forEach { $0.resume() }
         }
     }
 

--- a/Tests/AppleSpeechTests/AppleSpeechTests.swift
+++ b/Tests/AppleSpeechTests/AppleSpeechTests.swift
@@ -37,6 +37,18 @@ final class AppleSpeechTests: XCTestCase {
 
     // MARK: - Authorization Tests
 
+    func testBenignTerminalErrorDetectsNoSpeechError() {
+        let error = NSError(domain: "kAFAssistantErrorDomain", code: 1110)
+
+        XCTAssertTrue(isBenignAppleSpeechTerminalError(error))
+    }
+
+    func testBenignTerminalErrorRejectsOtherErrors() {
+        let error = NSError(domain: "kAFAssistantErrorDomain", code: 1101)
+
+        XCTAssertFalse(isBenignAppleSpeechTerminalError(error))
+    }
+
     func testRequestAuthorizationReturnsStatus() async {
         let status = await AppleSpeech.requestAuthorization()
 

--- a/Tests/LangToolsTests/ProviderAbstractionsTests.swift
+++ b/Tests/LangToolsTests/ProviderAbstractionsTests.swift
@@ -1,3 +1,7 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import XCTest
 @testable import LangTools
 
@@ -51,6 +55,19 @@ final class ProviderAbstractionsTests: XCTestCase {
         let response: any LangToolsAudioResponse = data
 
         XCTAssertEqual(response.audioData, data)
+    }
+
+    func testPerformUsesAudioResponseInitializerForRawAudioBytes() async throws {
+        let audioData = Data([0x00, 0x01, 0x02, 0x03])
+        RawAudioResponseURLProtocol.responseData = audioData
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RawAudioResponseURLProtocol.self]
+        let langTool = RawAudioLangTool(session: URLSession(configuration: configuration))
+
+        let response = try await langTool.perform(request: RawAudioRequest())
+
+        XCTAssertEqual(response.audioData, audioData)
+        XCTAssertTrue(response.initializedFromAudioData)
     }
 
     // MARK: - State equality
@@ -302,4 +319,76 @@ final class ProviderAbstractionsTests: XCTestCase {
 
         XCTAssertEqual(response.transcriptText, "bytes: 3")
     }
+}
+
+private struct RawAudioResponse: Decodable, LangToolsAudioResponse {
+    let audioData: Data
+    let initializedFromAudioData: Bool
+
+    init(audioData: Data) throws {
+        self.audioData = audioData
+        initializedFromAudioData = true
+    }
+
+    init(from decoder: Decoder) throws {
+        throw DecodingError.dataCorrupted(
+            .init(codingPath: decoder.codingPath, debugDescription: "Raw audio bytes are not JSON-decodable")
+        )
+    }
+}
+
+private struct RawAudioRequest: LangToolsRequest {
+    typealias LangTool = RawAudioLangTool
+    typealias Response = RawAudioResponse
+
+    static let endpoint = "audio"
+}
+
+private enum RawAudioModel: String {
+    case mock
+}
+
+private struct RawAudioErrorResponse: Codable, Error {}
+
+private struct RawAudioLangTool: LangTools {
+    typealias Model = RawAudioModel
+    typealias ErrorResponse = RawAudioErrorResponse
+
+    static let requestValidators: [(any LangToolsRequest) -> Bool] = [{ $0 is RawAudioRequest }]
+    let session: URLSession
+
+    static func chatRequest(
+        model: any RawRepresentable,
+        messages: [any LangToolsMessage],
+        tools: [any LangToolsTool]?,
+        responseSchema: JSONSchema?,
+        toolEventHandler: @escaping (LangToolsToolEvent) -> Void
+    ) throws -> any LangToolsChatRequest {
+        throw LangToolsError.invalidArgument("RawAudioLangTool does not support chat requests")
+    }
+
+    func prepare(request: some LangToolsRequest) throws -> URLRequest {
+        URLRequest(url: URL(string: "https://example.com/audio")!)
+    }
+}
+
+private final class RawAudioResponseURLProtocol: URLProtocol {
+    static var responseData = Data()
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.responseData)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }

--- a/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
+++ b/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
@@ -52,6 +52,24 @@ final class WhisperKitSpeechRecognitionProviderTests: XCTestCase {
         )
     }
 
+    #if DEBUG
+    @MainActor
+    func testPendingInitializationWaitersResumeOnSuccess() async throws {
+        let provider = WhisperKitSpeechRecognitionProvider()
+        provider.test_beginInitialization()
+
+        let waiter = Task { @MainActor in
+            try await provider.test_enqueuePendingInitializationContinuation()
+        }
+        await Task.yield()
+
+        provider.test_completeInitializationForTesting()
+
+        try await waiter.value
+        XCTAssertFalse(provider.test_isInitializing)
+        XCTAssertFalse(provider.test_hasPendingInitializationContinuations)
+    }
+
     @MainActor
     func testPendingInitializationWaitersResumeOnCancellation() async {
         let provider = WhisperKitSpeechRecognitionProvider()
@@ -95,5 +113,6 @@ final class WhisperKitSpeechRecognitionProviderTests: XCTestCase {
             XCTFail("Expected CancellationError, got \(error)")
         }
     }
+    #endif
 }
 #endif

--- a/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
+++ b/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
@@ -73,5 +73,27 @@ final class WhisperKitSpeechRecognitionProviderTests: XCTestCase {
             XCTFail("Expected CancellationError, got \(error)")
         }
     }
+
+    @MainActor
+    func testPendingInitializationWaiterObservesCallerCancellation() async {
+        let provider = WhisperKitSpeechRecognitionProvider()
+        provider.test_beginInitialization()
+
+        let waiter = Task { @MainActor in
+            try await provider.test_enqueuePendingInitializationContinuation()
+        }
+        await Task.yield()
+
+        waiter.cancel()
+
+        do {
+            _ = try await waiter.value
+            XCTFail("Expected initialization waiter to throw cancellation")
+        } catch is CancellationError {
+            XCTAssertFalse(provider.test_hasPendingInitializationContinuations)
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
 }
 #endif

--- a/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
+++ b/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
@@ -51,5 +51,27 @@ final class WhisperKitSpeechRecognitionProviderTests: XCTestCase {
             "Hello there friend"
         )
     }
+
+    @MainActor
+    func testPendingInitializationWaitersResumeOnCancellation() async {
+        let provider = WhisperKitSpeechRecognitionProvider()
+        provider.test_beginInitialization()
+
+        let waiter = Task { @MainActor in
+            try await provider.test_enqueuePendingInitializationContinuation()
+        }
+        await Task.yield()
+
+        provider.test_cancelInitializationForTesting()
+
+        do {
+            _ = try await waiter.value
+            XCTFail("Expected initialization waiter to resume with cancellation")
+        } catch is CancellationError {
+            XCTAssertFalse(provider.test_isInitializing)
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
 }
 #endif


### PR DESCRIPTION
Addresses bugs and warnings identified in the code review of PR #34.

## Changes

- **AppleSpeechRecognitionProvider**: emit `.recognitionFailed` before `cleanupStreaming()` so listeners can exit recording state on real recognition failures.
- **AppleSpeechRecognitionProvider**: treat Apple Speech's no-speech terminal error (`kAFAssistantErrorDomain` code 1110) as an empty final completion instead of a user-facing error on normal empty stops.
- **STTService**: reset `isRecording` / `isProcessing` in the `.recognitionFailed` event handler for all providers.
- **STTService**: surface final-chunk append errors in `stopOpenAIChunkedStreaming` and stop provider-owned streaming on that error path so OpenAI streaming state/handlers are cleaned up.
- **LangTools+Speech**: add `init(audioData:)` to `LangToolsAudioResponse`; keep stdlib conformances Swift 5.9/5.10-compatible by avoiding Swift 6-only `@retroactive` syntax.
- **LangTools**: widen the `perform` raw-audio fast path to any `LangToolsAudioResponse` conformer by constructing responses with `init(audioData:)` before falling back to JSON decoding.
- **WhisperKitSpeechRecognitionProvider**: await in-flight initialization via continuation queue instead of returning silently.
- **WhisperKitSpeechRecognitionProvider**: resume pending initialization waiters on success, cancellation, reset, and caller cancellation; re-check requested model variant after waiting.
- **WhisperKit tests**: keep test-only initialization helpers out of release target builds and cover successful/cancelled waiter resumption.

References: #34

## Validation

- `swift test --filter AppleSpeechTests` — 18 selected Apple tests passed.
- `swift test --filter WhisperKitSpeechRecognitionProviderTests` — 8 tests passed.
- `swift test --filter ProviderAbstractionsTests` — 14 tests passed.
- `swift build -c release --target WhisperKitLangTools && swift build -c release --target AppleLangTools` — passed.
- `swift build -c release --target LangTools` — passed.
- `swift test` — 249 tests passed.
- `git diff --check` — passed.
- `xcodebuild -workspace LangTools.xcworkspace -list` was previously blocked by an existing missing example package manifest: `Examples/LangTools_Example/ChatUI/Package.swift`.

Generated with [Claude Code](https://claude.ai/code)

