### PR TITLE
refactor: remove dual-language/auto-detect from core speech protocol

### DIFF
--- a/Examples/LangTools_Example/Modules/Audio/STTProvider.swift
+++ b/Examples/LangTools_Example/Modules/Audio/STTProvider.swift
@@ -56,10 +56,6 @@ public extension SpeechRecognitionProvider {
     }
 
     func prepareAssetsIfNeeded() {}
-
-    func startDualLanguageRecognition(otherLanguageIdentifier: String) throws {
-        throw STTError.notAvailable
-    }
 }
 
 /// Settings needed by Audio without depending on the Chat module's concrete settings store.

--- a/Examples/LangTools_Example/Modules/Audio/STTService.swift
+++ b/Examples/LangTools_Example/Modules/Audio/STTService.swift
@@ -341,7 +341,7 @@ public class STTService: ObservableObject {
         switch event {
         case .partialTranscription(let text):
             if !text.isEmpty { partialTranscription = text }
-        case .finalTranscription(let text), .dualLanguageFinalTranscription(let text, _):
+        case .finalTranscription(let text):
             transcribedText = text
             partialTranscription = ""
             isRecording = false
@@ -350,8 +350,6 @@ public class STTService: ObservableObject {
         case .recognitionFailed(let message):
             error = .transcriptionFailed(message)
             status = .error(message)
-        case .autoDetectLanguageSwitch:
-            break
         }
     }
 

--- a/Examples/LangTools_Example/Modules/ToolKit/ExampleTranslationProvider.swift
+++ b/Examples/LangTools_Example/Modules/ToolKit/ExampleTranslationProvider.swift
@@ -14,7 +14,6 @@ public struct ExampleTranslationProvider: TextTranslationProviding {
         runsOnDevice: true,
         supportsStreamingPartials: false,
         supportsContinuousMode: false,
-        supportsDualLanguageAutoDetect: false,
         requiresNetwork: false,
         requiresModelDownload: false
     )

--- a/Sources/Apple/AppleSpeechRecognitionProvider.swift
+++ b/Sources/Apple/AppleSpeechRecognitionProvider.swift
@@ -24,7 +24,6 @@ public final class AppleSpeechRecognitionProvider: StreamingSpeechRecognitionPro
         runsOnDevice: true,
         supportsStreamingPartials: true,
         supportsContinuousMode: true,
-        supportsDualLanguageAutoDetect: false,
         requiresNetwork: false,
         requiresModelDownload: false
     )
@@ -125,10 +124,6 @@ public final class AppleSpeechRecognitionProvider: StreamingSpeechRecognitionPro
     public func startRecognition() throws {
         updateLocaleFromSettings()
         try startStreamingTranscription(onPartialResult: { _ in }, onFinalResult: { _ in })
-    }
-
-    public func startDualLanguageRecognition(otherLanguageIdentifier: String) throws {
-        throw AppleLangToolsSpeechError.notAvailable
     }
 
     public func stopRecognition(finalizePending: Bool, clearTranscript: Bool) {

--- a/Sources/LangTools/LangTools+Providers.swift
+++ b/Sources/LangTools/LangTools+Providers.swift
@@ -27,7 +27,6 @@ public struct ProviderCapabilities: Equatable, Sendable {
     public let runsOnDevice: Bool
     public let supportsStreamingPartials: Bool
     public let supportsContinuousMode: Bool
-    public let supportsDualLanguageAutoDetect: Bool
     public let requiresNetwork: Bool
     public let requiresModelDownload: Bool
 
@@ -35,14 +34,12 @@ public struct ProviderCapabilities: Equatable, Sendable {
         runsOnDevice: Bool,
         supportsStreamingPartials: Bool = false,
         supportsContinuousMode: Bool = false,
-        supportsDualLanguageAutoDetect: Bool = false,
         requiresNetwork: Bool = false,
         requiresModelDownload: Bool = false
     ) {
         self.runsOnDevice = runsOnDevice
         self.supportsStreamingPartials = supportsStreamingPartials
         self.supportsContinuousMode = supportsContinuousMode
-        self.supportsDualLanguageAutoDetect = supportsDualLanguageAutoDetect
         self.requiresNetwork = requiresNetwork
         self.requiresModelDownload = requiresModelDownload
     }
@@ -67,21 +64,10 @@ public enum ProviderAssetState: Equatable, Sendable {
     case failed(reason: String)
 }
 
-/// Language selected during dual-language speech recognition.
-public enum SpeechAutoDetectWinner: Equatable, Sendable {
-    case primary
-    case secondary
-    /// No winner was determined (e.g. inconclusive detection). Named `undetected`
-    /// rather than `none` to avoid shadowing `Optional.none` in generic contexts.
-    case undetected
-}
-
 /// Speech recognition events emitted by an STT provider.
 public enum SpeechRecognitionEvent: Equatable, Sendable {
     case partialTranscription(String)
     case finalTranscription(String)
-    case dualLanguageFinalTranscription(String, winner: SpeechAutoDetectWinner)
-    case autoDetectLanguageSwitch
     case recognitionFailed(String)
 }
 
@@ -109,8 +95,6 @@ public protocol SpeechRecognitionProviding: AnyObject {
     /// Transcribe already-captured audio data in a provider-supported format.
     func transcribe(audioData: Data) async throws -> any LangToolsTranscriptionResponse
     func startRecognition() throws
-    @available(iOS 16, macOS 13, *)
-    func startDualLanguageRecognition(otherLanguageIdentifier: String) throws
     func stopRecognition(finalizePending: Bool, clearTranscript: Bool)
     func finalizeRecognition()
 }

--- a/Sources/OpenAI/OpenAISpeechRecognitionProvider.swift
+++ b/Sources/OpenAI/OpenAISpeechRecognitionProvider.swift
@@ -22,7 +22,6 @@ open class OpenAISpeechRecognitionProvider: StreamingSpeechRecognitionProviding 
         runsOnDevice: false,
         supportsStreamingPartials: false,
         supportsContinuousMode: false,
-        supportsDualLanguageAutoDetect: false,
         requiresNetwork: true,
         requiresModelDownload: false
     )
@@ -125,10 +124,6 @@ open class OpenAISpeechRecognitionProvider: StreamingSpeechRecognitionProviding 
     public func prepareAssetsIfNeeded() {}
 
     public func startRecognition() throws {
-        throw OpenAISpeechProviderError.liveRecognitionUnsupported
-    }
-
-    public func startDualLanguageRecognition(otherLanguageIdentifier: String) throws {
         throw OpenAISpeechProviderError.liveRecognitionUnsupported
     }
 

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -41,7 +41,6 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
         runsOnDevice: true,
         supportsStreamingPartials: true,
         supportsContinuousMode: true,
-        supportsDualLanguageAutoDetect: false,
         requiresNetwork: false,
         requiresModelDownload: true
     )
@@ -148,10 +147,6 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
                 self.eventHandler?(.recognitionFailed(speechError.localizedDescription))
             }
         }
-    }
-
-    public func startDualLanguageRecognition(otherLanguageIdentifier: String) throws {
-        throw WhisperKitLangToolsSpeechError.notAvailable
     }
 
     public func stopRecognition(finalizePending: Bool, clearTranscript: Bool) {

--- a/Tests/LangToolsTests/ProviderAbstractionsTests.swift
+++ b/Tests/LangToolsTests/ProviderAbstractionsTests.swift
@@ -7,7 +7,6 @@ final class ProviderAbstractionsTests: XCTestCase {
             runsOnDevice: true,
             supportsStreamingPartials: false,
             supportsContinuousMode: false,
-            supportsDualLanguageAutoDetect: false,
             requiresNetwork: false,
             requiresModelDownload: true
         )
@@ -15,7 +14,6 @@ final class ProviderAbstractionsTests: XCTestCase {
         XCTAssertTrue(capabilities.runsOnDevice)
         XCTAssertFalse(capabilities.supportsStreamingPartials)
         XCTAssertFalse(capabilities.supportsContinuousMode)
-        XCTAssertFalse(capabilities.supportsDualLanguageAutoDetect)
         XCTAssertFalse(capabilities.requiresNetwork)
         XCTAssertTrue(capabilities.requiresModelDownload)
     }
@@ -72,13 +70,6 @@ final class ProviderAbstractionsTests: XCTestCase {
         XCTAssertNotEqual(ProviderAssetState.failed(reason: "a"), .failed(reason: "b"))
     }
 
-    func testSpeechAutoDetectWinnerUndetectedNotNilAmbiguous() {
-        let winner = SpeechAutoDetectWinner.undetected
-        XCTAssertNotEqual(winner, .primary)
-        XCTAssertNotEqual(winner, .secondary)
-        XCTAssertEqual(winner, .undetected)
-    }
-
     // MARK: - Generic abstraction boundary
 
     func testGenericTTSBoundaryAcceptsAnyLangToolsSpeechSynthesisRequest() {
@@ -132,7 +123,6 @@ final class ProviderAbstractionsTests: XCTestCase {
             func refreshAuthorizationState() {}
             func prepareAssetsIfNeeded() {}
             func startRecognition() throws {}
-            func startDualLanguageRecognition(otherLanguageIdentifier: String) throws {}
             func stopRecognition(finalizePending: Bool, clearTranscript: Bool) {}
             func finalizeRecognition() {}
 
@@ -187,7 +177,6 @@ final class ProviderAbstractionsTests: XCTestCase {
             func refreshAuthorizationState() {}
             func prepareAssetsIfNeeded() {}
             func startRecognition() throws {}
-            func startDualLanguageRecognition(otherLanguageIdentifier: String) throws {}
             func stopRecognition(finalizePending: Bool, clearTranscript: Bool) {}
             func finalizeRecognition() {}
 
@@ -254,7 +243,6 @@ final class ProviderAbstractionsTests: XCTestCase {
             func refreshAuthorizationState() {}
             func prepareAssetsIfNeeded() {}
             func startRecognition() throws {}
-            func startDualLanguageRecognition(otherLanguageIdentifier: String) throws {}
             func stopRecognition(finalizePending: Bool, clearTranscript: Bool) {}
             func finalizeRecognition() {}
 
@@ -301,7 +289,6 @@ final class ProviderAbstractionsTests: XCTestCase {
             func refreshAuthorizationState() {}
             func prepareAssetsIfNeeded() {}
             func startRecognition() throws {}
-            func startDualLanguageRecognition(otherLanguageIdentifier: String) throws {}
             func stopRecognition(finalizePending: Bool, clearTranscript: Bool) {}
             func finalizeRecognition() {}
 


### PR DESCRIPTION
Addresses @rchatham's request on #034: dual-language/auto-detect should not be part of the default `SpeechRecognitionProviding` surface in `LangTools.swift` yet.

## Changes

- Removed `startDualLanguageRecognition` from `SpeechRecognitionProviding`
- Removed `SpeechAutoDetectWinner`, `.dualLanguageFinalTranscription`, `.autoDetectLanguageSwitch`, and `supportsDualLanguageAutoDetect`
- Removed now-dead stub implementations from Apple/OpenAI/WhisperKit providers and the example app
- Updated tests accordingly

No conformer implemented this beyond throwing "not available", so this is a clean removal. A future opt-in protocol can reintroduce dual-language/auto-detect support once a real provider needs it.

References: #034

Generated with [Claude Code](https://claude.ai/code)