### PR TITLE
fix: revert playAudio to route directly through langToolchain

### DIFF
--- a/Examples/LangTools_Example/Modules/Chat/Services/NetworkClient.swift
+++ b/Examples/LangTools_Example/Modules/Chat/Services/NetworkClient.swift
@@ -14,17 +14,6 @@ import Ollama
 
 public typealias Role = OpenAI.Message.Role
 
-public enum NetworkClientError: Error, LocalizedError {
-    case missingLangTool(String)
-
-    public var errorDescription: String? {
-        switch self {
-        case .missingLangTool(let name):
-            return "Missing registered LangTool: \(name)"
-        }
-    }
-}
-
 public protocol NetworkClientProtocol {
     static var shared: NetworkClientProtocol { get }
     func performChatCompletionRequest(messages: [Message], model: Model, tools: [Tool]?, toolChoice: OpenAI.ChatCompletionRequest.ToolChoice?) async throws -> Message
@@ -82,16 +71,9 @@ public class NetworkClient: NSObject, NetworkClientProtocol {
     }
 
     public func playAudio(for text: String) async throws {
-        guard let openAI = langToolchain.langTool(OpenAI.self) else {
-            throw NetworkClientError.missingLangTool("OpenAI")
-        }
-
-        let provider = await MainActor.run {
-            OpenAISpeechSynthesisProvider(openAI: openAI, model: .tts_1_hd)
-        }
-        let request = LangToolsSpeechSynthesisInput(text: text, languageIdentifier: "en", voiceIdentifier: "alloy", rate: 1.2)
-        let audioResponse = try await provider.synthesize(request, voice: .alloy)
-        do { try AudioPlayer.shared.play(data: audioResponse.audioData) }
+        let audioReq = OpenAI.AudioSpeechRequest(model: .tts_1_hd, input: text, voice: .alloy, responseFormat: .mp3, speed: 1.2)
+        let audioResponse: Data = try await langToolchain.perform(request: audioReq)
+        do { try AudioPlayer.shared.play(data: audioResponse) }
         catch { print(error.localizedDescription) }
     }
 


### PR DESCRIPTION
Addresses @rchatham's feedback on #034: the `OpenAISpeechSynthesisProvider` guard in `NetworkClient.playAudio` was unnecessary since `langToolchain.perform(request:)` already throws when it can't handle a request.

## Changes

- Reverted `playAudio(for:)` to build `OpenAI.AudioSpeechRequest` inline and call `langToolchain.perform(request:)` directly, matching the pre-PR #34 implementation
- Removed the now-unused `NetworkClientError.missingLangTool` case

References: #034

Generated with [Claude Code](https://claude.ai/code)