### PR TITLE
fix(speech): standardize WhisperKit streaming startup

### DIFF
--- a/Sources/Apple/AppleSpeechRecognitionProvider.swift
+++ b/Sources/Apple/AppleSpeechRecognitionProvider.swift
@@ -183,10 +183,10 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
         recognitionSessionID = sessionID
 
         recognitionTask = recognizer.recognitionTask(with: recognitionRequest) { [weak self] result, error in
-            if error != nil {
+            if let error {
                 Task { @MainActor [weak self] in
                     guard let self, self.recognitionSessionID == sessionID else { return }
-                    self.cleanupStreaming()
+                    self.handleStreamingFailure(error)
                 }
                 return
             }
@@ -303,6 +303,19 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
 
     func resetStreamingTranscriptState() {
         currentTranscript = ""
+    }
+
+    func test_failStreamingForTesting(_ error: Error) async throws -> String? {
+        try await withCheckedThrowingContinuation { continuation in
+            blockingStreamingContinuation = continuation
+            handleStreamingFailure(error)
+        }
+    }
+
+    private func handleStreamingFailure(_ error: Error) {
+        eventHandler?(.recognitionFailed(error.localizedDescription))
+        completeBlockingStreaming(throwing: error)
+        cleanupStreaming(completeBlockingContinuation: false)
     }
 
     private func cleanupStreaming(completeBlockingContinuation: Bool = true) {

--- a/Sources/Apple/AppleSpeechRecognitionProvider.swift
+++ b/Sources/Apple/AppleSpeechRecognitionProvider.swift
@@ -17,7 +17,7 @@ private extension SFSpeechRecognizerAuthorizationStatus {
 
 /// Reusable Apple Speech recognition provider adapter.
 @MainActor
-public final class AppleSpeechRecognitionProvider: StreamingSpeechRecognitionProviding {
+public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecognitionProviding {
     public let providerID = LangToolsProviderID(rawValue: "apple.speech")
     public let displayName = "Apple Speech"
     public let capabilities = ProviderCapabilities(
@@ -44,6 +44,7 @@ public final class AppleSpeechRecognitionProvider: StreamingSpeechRecognitionPro
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionSessionID = UUID()
     private var streamingFinalizeCleanupTask: Task<Void, Never>?
+    private var blockingStreamingContinuation: CheckedContinuation<String?, Error>?
     private var onPartialResultCallback: ((String) -> Void)?
     private var onFinalResultCallback: ((String) -> Void)?
     private var languageIdentifierProvider: @MainActor () -> String?
@@ -255,6 +256,34 @@ public final class AppleSpeechRecognitionProvider: StreamingSpeechRecognitionPro
         stopStreamingTranscription()
     }
 
+    @discardableResult
+    public func runStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws -> String? {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                blockingStreamingContinuation = continuation
+                do {
+                    try startStreamingTranscription(
+                        onPartialResult: { text in
+                            onEvent(.partialTranscription(text))
+                        },
+                        onFinalResult: { [weak self] text in
+                            onEvent(.finalTranscription(text))
+                            self?.completeBlockingStreaming(returning: text.isEmpty ? nil : text)
+                        }
+                    )
+                } catch {
+                    blockingStreamingContinuation = nil
+                    continuation.resume(throwing: error)
+                }
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.completeBlockingStreaming(throwing: CancellationError())
+                self?.cancelStreamingTranscription()
+            }
+        }
+    }
+
     private func scheduleStreamingFinalizeCleanup(for sessionID: UUID) {
         streamingFinalizeCleanupTask?.cancel()
         streamingFinalizeCleanupTask = Task { [weak self] in
@@ -269,6 +298,7 @@ public final class AppleSpeechRecognitionProvider: StreamingSpeechRecognitionPro
     }
 
     private func cleanupStreaming() {
+        completeBlockingStreaming(returning: currentTranscript.isEmpty ? nil : currentTranscript)
         streamingFinalizeCleanupTask?.cancel()
         streamingFinalizeCleanupTask = nil
         isListening = false
@@ -281,6 +311,18 @@ public final class AppleSpeechRecognitionProvider: StreamingSpeechRecognitionPro
         recognitionSessionID = UUID()
         onPartialResultCallback = nil
         onFinalResultCallback = nil
+    }
+
+    private func completeBlockingStreaming(returning text: String?) {
+        guard let continuation = blockingStreamingContinuation else { return }
+        blockingStreamingContinuation = nil
+        continuation.resume(returning: text)
+    }
+
+    private func completeBlockingStreaming(throwing error: Error) {
+        guard let continuation = blockingStreamingContinuation else { return }
+        blockingStreamingContinuation = nil
+        continuation.resume(throwing: error)
     }
 }
 

--- a/Sources/Apple/AppleSpeechRecognitionProvider.swift
+++ b/Sources/Apple/AppleSpeechRecognitionProvider.swift
@@ -154,6 +154,7 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
             throw AppleLangToolsSpeechError.permissionDenied
         }
 
+        resetStreamingTranscriptState()
         onPartialResultCallback = onPartialResult
         onFinalResultCallback = onFinalResult
 
@@ -295,6 +296,14 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
                 self.cleanupStreaming()
             }
         }
+    }
+
+    func setStreamingTranscriptForTesting(_ text: String) {
+        currentTranscript = text
+    }
+
+    func resetStreamingTranscriptState() {
+        currentTranscript = ""
     }
 
     private func cleanupStreaming() {

--- a/Sources/Apple/AppleSpeechRecognitionProvider.swift
+++ b/Sources/Apple/AppleSpeechRecognitionProvider.swift
@@ -47,6 +47,7 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
     private var blockingStreamingContinuation: CheckedContinuation<String?, Error>?
     private var onPartialResultCallback: ((String) -> Void)?
     private var onFinalResultCallback: ((String) -> Void)?
+    private var onFailureCallback: ((Error) -> Void)?
     private var languageIdentifierProvider: @MainActor () -> String?
 
     public init(
@@ -144,7 +145,8 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
 
     public func startStreamingTranscription(
         onPartialResult: @escaping (String) -> Void,
-        onFinalResult: @escaping (String) -> Void
+        onFinalResult: @escaping (String) -> Void,
+        onFailure: ((Error) -> Void)? = nil
     ) throws {
         updateLocaleFromSettings()
         guard let recognizer = speechRecognizer, recognizer.isAvailable else {
@@ -157,6 +159,7 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
         resetStreamingTranscriptState()
         onPartialResultCallback = onPartialResult
         onFinalResultCallback = onFinalResult
+        onFailureCallback = onFailure
 
         #if os(iOS)
         let audioSession = AVAudioSession.sharedInstance()
@@ -249,6 +252,9 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
             },
             onFinalResult: { text in
                 onEvent(.finalTranscription(text))
+            },
+            onFailure: { error in
+                onEvent(.recognitionFailed(error.localizedDescription))
             }
         )
     }
@@ -270,6 +276,9 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
                         onFinalResult: { [weak self] text in
                             onEvent(.finalTranscription(text))
                             self?.completeBlockingStreaming(returning: text.isEmpty ? nil : text)
+                        },
+                        onFailure: { error in
+                            onEvent(.recognitionFailed(error.localizedDescription))
                         }
                     )
                 } catch {
@@ -305,8 +314,12 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
         currentTranscript = ""
     }
 
-    func test_failStreamingForTesting(_ error: Error) async throws -> String? {
-        try await withCheckedThrowingContinuation { continuation in
+    func test_failStreamingForTesting(
+        _ error: Error,
+        onFailure: ((Error) -> Void)? = nil
+    ) async throws -> String? {
+        self.onFailureCallback = onFailure
+        return try await withCheckedThrowingContinuation { continuation in
             blockingStreamingContinuation = continuation
             handleStreamingFailure(error)
         }
@@ -314,6 +327,7 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
 
     private func handleStreamingFailure(_ error: Error) {
         eventHandler?(.recognitionFailed(error.localizedDescription))
+        onFailureCallback?(error)
         completeBlockingStreaming(throwing: error)
         cleanupStreaming(completeBlockingContinuation: false)
     }
@@ -334,6 +348,7 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
         recognitionSessionID = UUID()
         onPartialResultCallback = nil
         onFinalResultCallback = nil
+        onFailureCallback = nil
     }
 
     private func completeBlockingStreaming(returning text: String?) {

--- a/Sources/Apple/AppleSpeechRecognitionProvider.swift
+++ b/Sources/Apple/AppleSpeechRecognitionProvider.swift
@@ -175,7 +175,7 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
         let inputNode = audioEngine.inputNode
         let hwFormat = inputNode.inputFormat(forBus: 0)
         guard hwFormat.sampleRate > 0 && hwFormat.channelCount > 0 else {
-            cleanupStreaming()
+            cleanupStreaming(completeBlockingContinuation: false)
             throw AppleLangToolsSpeechError.recordingFailed("No valid audio input device available")
         }
 
@@ -217,7 +217,7 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
             try audioEngine.start()
             isListening = true
         } catch {
-            cleanupStreaming()
+            cleanupStreaming(completeBlockingContinuation: false)
             throw error
         }
     }
@@ -273,8 +273,7 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
                         }
                     )
                 } catch {
-                    blockingStreamingContinuation = nil
-                    continuation.resume(throwing: error)
+                    completeBlockingStreaming(throwing: error)
                 }
             }
         } onCancel: {
@@ -306,8 +305,10 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
         currentTranscript = ""
     }
 
-    private func cleanupStreaming() {
-        completeBlockingStreaming(returning: currentTranscript.isEmpty ? nil : currentTranscript)
+    private func cleanupStreaming(completeBlockingContinuation: Bool = true) {
+        if completeBlockingContinuation {
+            completeBlockingStreaming(returning: currentTranscript.isEmpty ? nil : currentTranscript)
+        }
         streamingFinalizeCleanupTask?.cancel()
         streamingFinalizeCleanupTask = nil
         isListening = false

--- a/Sources/Apple/AppleSpeechRecognitionProvider.swift
+++ b/Sources/Apple/AppleSpeechRecognitionProvider.swift
@@ -125,7 +125,17 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
 
     public func startRecognition() throws {
         updateLocaleFromSettings()
-        try startStreamingTranscription(onPartialResult: { _ in }, onFinalResult: { _ in })
+        try startStreamingTranscription(
+            onPartialResult: { [weak self] text in
+                self?.eventHandler?(.partialTranscription(text))
+            },
+            onFinalResult: { [weak self] text in
+                self?.eventHandler?(.finalTranscription(text))
+            },
+            onFailure: { [weak self] error in
+                self?.eventHandler?(.recognitionFailed(error.localizedDescription))
+            }
+        )
     }
 
     public func stopRecognition(finalizePending: Bool, clearTranscript: Bool) {
@@ -200,12 +210,10 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
                 guard let self, self.recognitionSessionID == sessionID else { return }
                 if isFinal {
                     self.currentTranscript = text
-                    self.eventHandler?(.finalTranscription(text))
                     self.onFinalResultCallback?(text)
                     self.cleanupStreaming()
                 } else {
                     self.currentTranscript = text
-                    self.eventHandler?(.partialTranscription(text))
                     self.onPartialResultCallback?(text)
                 }
             }
@@ -267,7 +275,7 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
     public func runStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws -> String? {
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                blockingStreamingContinuation = continuation
+                guard storeBlockingStreamingContinuation(continuation) else { return }
                 do {
                     try startStreamingTranscription(
                         onPartialResult: { text in
@@ -320,13 +328,33 @@ public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecogn
     ) async throws -> String? {
         self.onFailureCallback = onFailure
         return try await withCheckedThrowingContinuation { continuation in
-            blockingStreamingContinuation = continuation
+            guard storeBlockingStreamingContinuation(continuation) else { return }
             handleStreamingFailure(error)
         }
     }
 
+    func test_runBlockedStreamingForTesting() async throws -> String? {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                guard storeBlockingStreamingContinuation(continuation) else { return }
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.completeBlockingStreaming(throwing: CancellationError())
+            }
+        }
+    }
+
+    private func storeBlockingStreamingContinuation(_ continuation: CheckedContinuation<String?, Error>) -> Bool {
+        guard blockingStreamingContinuation == nil else {
+            continuation.resume(throwing: AppleLangToolsSpeechError.recordingFailed("Streaming recognition is already active"))
+            return false
+        }
+        blockingStreamingContinuation = continuation
+        return true
+    }
+
     private func handleStreamingFailure(_ error: Error) {
-        eventHandler?(.recognitionFailed(error.localizedDescription))
         onFailureCallback?(error)
         completeBlockingStreaming(throwing: error)
         cleanupStreaming(completeBlockingContinuation: false)

--- a/Sources/Apple/AppleSpeechRecognitionProvider.swift
+++ b/Sources/Apple/AppleSpeechRecognitionProvider.swift
@@ -17,7 +17,7 @@ private extension SFSpeechRecognizerAuthorizationStatus {
 
 /// Reusable Apple Speech recognition provider adapter.
 @MainActor
-public final class AppleSpeechRecognitionProvider: BlockingStreamingSpeechRecognitionProviding {
+public final class AppleSpeechRecognitionProvider: StreamingSpeechRecognitionProviding {
     public let providerID = LangToolsProviderID(rawValue: "apple.speech")
     public let displayName = "Apple Speech"
     public let capabilities = ProviderCapabilities(

--- a/Sources/LangTools/LangTools+Providers.swift
+++ b/Sources/LangTools/LangTools+Providers.swift
@@ -106,6 +106,7 @@ public typealias SpeechRecognitionStreamingEventHandler = @MainActor @Sendable (
 public enum StreamingSpeechRecognitionError: Error, LocalizedError, Equatable, Sendable {
     case externalAudioUnsupported
     case notStreaming
+    case recognitionFailed(String)
 
     public var errorDescription: String? {
         switch self {
@@ -113,6 +114,8 @@ public enum StreamingSpeechRecognitionError: Error, LocalizedError, Equatable, S
             return "This speech recognition provider does not accept externally captured streaming audio"
         case .notStreaming:
             return "Speech recognition streaming has not started"
+        case .recognitionFailed(let message):
+            return message
         }
     }
 }
@@ -142,6 +145,11 @@ public protocol StreamingSpeechRecognitionProviding: SpeechRecognitionProviding 
     /// Events continue asynchronously through `onEvent`; call `stopStreamingRecognition()`
     /// to end the stream and collect the best final transcript.
     func startStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws
+
+    /// Starts streaming recognition, suspends while recognition runs, and returns the
+    /// best final transcript once the stream ends, is cancelled, or fails.
+    @discardableResult
+    func runStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws -> String?
     /// Append externally captured audio during an active streaming session.
     ///
     /// Providers define whether `audioData` must be an incremental chunk or the
@@ -157,19 +165,62 @@ public extension StreamingSpeechRecognitionProviding {
     func appendStreamingAudio(_ audioData: Data) async throws {
         throw StreamingSpeechRecognitionError.externalAudioUnsupported
     }
+
+    @discardableResult
+    func runStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws -> String? {
+        let runState = DefaultStreamingRecognitionRunState()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                runState.store(continuation)
+                Task { @MainActor in
+                    do {
+                        try await startStreamingRecognition { event in
+                            onEvent(event)
+                            switch event {
+                            case .partialTranscription:
+                                break
+                            case .finalTranscription(let text):
+                                Task { @MainActor in
+                                    let finalText = await self.stopStreamingRecognition()
+                                    runState.complete(returning: finalText ?? (text.isEmpty ? nil : text))
+                                }
+                            case .recognitionFailed(let message):
+                                runState.complete(throwing: StreamingSpeechRecognitionError.recognitionFailed(message))
+                            }
+                        }
+                    } catch {
+                        runState.complete(throwing: error)
+                    }
+                }
+            }
+        } onCancel: {
+            Task { @MainActor in
+                _ = await self.stopStreamingRecognition()
+                runState.complete(throwing: CancellationError())
+            }
+        }
+    }
 }
 
-/// Optional STT provider contract for callers that want structured-concurrency
-/// streaming semantics: start capture, suspend while recognition runs, and return
-/// the best final transcript once the stream ends, is cancelled, or fails.
-///
-/// This is complementary to `StreamingSpeechRecognitionProviding`, whose
-/// `startStreamingRecognition(...)` method returns after startup and delivers
-/// events asynchronously.
 @MainActor
-public protocol BlockingStreamingSpeechRecognitionProviding: StreamingSpeechRecognitionProviding {
-    @discardableResult
-    func runStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws -> String?
+private final class DefaultStreamingRecognitionRunState {
+    private var continuation: CheckedContinuation<String?, Error>?
+
+    func store(_ continuation: CheckedContinuation<String?, Error>) {
+        self.continuation = continuation
+    }
+
+    func complete(returning text: String?) {
+        guard let continuation else { return }
+        self.continuation = nil
+        continuation.resume(returning: text)
+    }
+
+    func complete(throwing error: Error) {
+        guard let continuation else { return }
+        self.continuation = nil
+        continuation.resume(throwing: error)
+    }
 }
 
 /// A text translation request expressed in provider-neutral language IDs.

--- a/Sources/LangTools/LangTools+Providers.swift
+++ b/Sources/LangTools/LangTools+Providers.swift
@@ -159,6 +159,19 @@ public extension StreamingSpeechRecognitionProviding {
     }
 }
 
+/// Optional STT provider contract for callers that want structured-concurrency
+/// streaming semantics: start capture, suspend while recognition runs, and return
+/// the best final transcript once the stream ends, is cancelled, or fails.
+///
+/// This is complementary to `StreamingSpeechRecognitionProviding`, whose
+/// `startStreamingRecognition(...)` method returns after startup and delivers
+/// events asynchronously.
+@MainActor
+public protocol BlockingStreamingSpeechRecognitionProviding: StreamingSpeechRecognitionProviding {
+    @discardableResult
+    func runStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws -> String?
+}
+
 /// A text translation request expressed in provider-neutral language IDs.
 public struct LangToolsTextTranslationRequest: Equatable, Sendable {
     public let text: String

--- a/Sources/LangTools/LangTools+Providers.swift
+++ b/Sources/LangTools/LangTools+Providers.swift
@@ -138,6 +138,9 @@ public protocol StreamingSpeechRecognitionProviding: SpeechRecognitionProviding 
     /// `appendStreamingAudio(_:)` during an active streaming session.
     var supportsExternalAudioStreaming: Bool { get }
 
+    /// Starts provider-owned streaming and returns once capture startup has been requested.
+    /// Events continue asynchronously through `onEvent`; call `stopStreamingRecognition()`
+    /// to end the stream and collect the best final transcript.
     func startStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws
     /// Append externally captured audio during an active streaming session.
     ///

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -35,7 +35,7 @@ public enum WhisperKitLoadingState: Equatable, Sendable {
 /// Reusable WhisperKit speech-to-text provider adapter.
 @available(macOS 13, iOS 16, *)
 @MainActor
-public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechRecognitionProviding, ObservableObject {
+public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecognitionProviding, ObservableObject {
     public let providerID = LangToolsProviderID(rawValue: "whisperkit.local")
     public let displayName = "WhisperKit"
     public let capabilities = ProviderCapabilities(

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -64,7 +64,7 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
     private var initializationTask: Task<Void, Never>?
     private var streamTranscriptionTask: Task<Void, Never>?
     private var finalTranscriptionContinuation: CheckedContinuation<String, Never>?
-    var lastTranscribedText = ""
+    private(set) var lastTranscribedText = ""
     private var hasEmittedFinalTranscription = false
     private var isStoppingStreaming = false
 
@@ -407,7 +407,7 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
                 await MainActor.run { [weak self] in
                     guard let self else { return }
                     self.debugLog("AudioStreamTranscriber start returned")
-                    self.isStreaming = false
+                    self.finishStreamingSession(clearLastTranscribedText: false, resetTranscriber: false, cancelTask: false)
                 }
             } catch is CancellationError {
                 await MainActor.run { [weak self] in

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -316,6 +316,7 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
     }
 
     private func makeWhisperKitConfig(modelVariant: String) -> WhisperKitConfig {
+        // Keep the audio encoder off ANE to avoid observed AudioEncoder.mlmodelc load failures.
         let computeOptions = ModelComputeOptions(
             audioEncoderCompute: .cpuAndGPU,
             textDecoderCompute: .cpuAndNeuralEngine
@@ -359,11 +360,11 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
     @discardableResult
     public func runStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws -> String? {
         try await withTaskCancellationHandler {
+            resetStreamingTranscriptState()
             try await prepareStreamingTranscriber { text, isFinal in
                 onEvent(isFinal ? .finalTranscription(text) : .partialTranscription(text))
             }
 
-            resetStreamingTranscriptState()
             isStreaming = true
             debugLog("running AudioStreamTranscriber until stopped")
             do {
@@ -393,9 +394,9 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
         onPartialResult: @escaping (String, Bool) -> Void,
         onError: (@MainActor @Sendable (WhisperKitLangToolsSpeechError) -> Void)? = nil
     ) async throws {
+        resetStreamingTranscriptState()
         try await prepareStreamingTranscriber(onPartialResult: onPartialResult)
 
-        resetStreamingTranscriptState()
         isStreaming = true
         debugLog("starting AudioStreamTranscriber")
         let transcriber = audioStreamTranscriber
@@ -553,7 +554,6 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
         onError: (@MainActor @Sendable (WhisperKitLangToolsSpeechError) -> Void)?
     ) {
         lastError = speechError
-        eventHandler?(.recognitionFailed(speechError.localizedDescription))
         onError?(speechError)
     }
 

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -226,6 +226,12 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
         }
     }
 
+    /// Resets cached model/loading state.
+    ///
+    /// Callers should stop an active streaming session before calling `reset()`. This method
+    /// cancels outstanding initialization/startup tasks and clears provider state synchronously;
+    /// it does not wait for microphone capture teardown beyond the provider's cooperative
+    /// streaming-session cleanup.
     public func reset() {
         initializationTask?.cancel()
         initializationTask = nil

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -35,7 +35,7 @@ public enum WhisperKitLoadingState: Equatable, Sendable {
 /// Reusable WhisperKit speech-to-text provider adapter.
 @available(macOS 13, iOS 16, *)
 @MainActor
-public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecognitionProviding, ObservableObject {
+public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechRecognitionProviding, ObservableObject {
     public let providerID = LangToolsProviderID(rawValue: "whisperkit.local")
     public let displayName = "WhisperKit"
     public let capabilities = ProviderCapabilities(
@@ -345,6 +345,32 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
 
     public func stopStreamingRecognition() async -> String? {
         await stopStreamingTranscription()
+    }
+
+    @discardableResult
+    public func runStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws -> String? {
+        try await prepareStreamingTranscriber { text, isFinal in
+            onEvent(isFinal ? .finalTranscription(text) : .partialTranscription(text))
+        }
+
+        hasEmittedFinalTranscription = false
+        isStreaming = true
+        debugLog("running AudioStreamTranscriber until stopped")
+        do {
+            try await audioStreamTranscriber?.startStreamTranscription()
+            isStreaming = false
+            return currentTranscript.isEmpty ? nil : currentTranscript
+        } catch is CancellationError {
+            isStreaming = false
+            throw CancellationError()
+        } catch {
+            isStreaming = false
+            let speechError = error as? WhisperKitLangToolsSpeechError ?? .transcriptionFailed(error.localizedDescription)
+            lastError = speechError
+            eventHandler?(.recognitionFailed(speechError.localizedDescription))
+            debugLog("AudioStreamTranscriber run threw: \(speechError.localizedDescription)")
+            throw speechError
+        }
     }
 
     public func startStreamingTranscription(

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -344,8 +344,8 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
 
     public func startStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws {
         try await startStreamingTranscription(
-            onPartialResult: { text, isFinal in
-                onEvent(isFinal ? .finalTranscription(text) : .partialTranscription(text))
+            onPartialResult: { [weak self] text, isFinal in
+                self?.emitStreamingRecognitionEvent(text, isFinal: isFinal, onEvent: onEvent)
             },
             onError: { error in
                 onEvent(.recognitionFailed(error.localizedDescription))
@@ -361,8 +361,8 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
     public func runStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws -> String? {
         try await withTaskCancellationHandler {
             resetStreamingTranscriptState()
-            try await prepareStreamingTranscriber { text, isFinal in
-                onEvent(isFinal ? .finalTranscription(text) : .partialTranscription(text))
+            try await prepareStreamingTranscriber { [weak self] text, isFinal in
+                self?.emitStreamingRecognitionEvent(text, isFinal: isFinal, onEvent: onEvent)
             }
 
             isStreaming = true
@@ -477,7 +477,7 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
                 let isFinal = !newState.isRecording && oldState.isRecording
                 let oldFullText = (oldState.confirmedSegments.map { self.stripSpecialTokens($0.text) } + oldState.unconfirmedSegments.map { self.stripSpecialTokens($0.text) }).joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
                 if oldState.isRecording != newState.isRecording || oldState.confirmedSegments.count != newState.confirmedSegments.count || oldState.unconfirmedSegments.count != newState.unconfirmedSegments.count || isFinal {
-                    self.debugLog("stream state recording \(oldState.isRecording)->\(newState.isRecording) confirmed=\(newState.confirmedSegments.count) unconfirmed=\(newState.unconfirmedSegments.count) text=\(fullText.debugDescription) final=\(isFinal)")
+                    self.debugLog("stream state recording \(oldState.isRecording)->\(newState.isRecording) confirmed=\(newState.confirmedSegments.count) unconfirmed=\(newState.unconfirmedSegments.count) textLength=\(fullText.count) final=\(isFinal)")
                 }
                 if !fullText.isEmpty && (fullText != oldFullText || isFinal) {
                     onPartialResult(fullText, isFinal)
@@ -492,7 +492,7 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
     }
 
     public func stopStreamingTranscription() async -> String {
-        debugLog("stopStreamingTranscription begin hasTranscriber=\(audioStreamTranscriber != nil) lastText=\(lastTranscribedText.debugDescription)")
+        debugLog("stopStreamingTranscription begin hasTranscriber=\(audioStreamTranscriber != nil) lastTextLength=\(lastTranscribedText.count)")
         guard audioStreamTranscriber != nil else { return lastTranscribedText }
         guard finalTranscriptionContinuation == nil else { return lastTranscribedText }
         let result = await withCheckedContinuation { (continuation: CheckedContinuation<String, Never>) in
@@ -505,7 +505,7 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
             }
         }
         finishStreamingSession(clearLastTranscribedText: true, resetTranscriber: false)
-        debugLog("stopStreamingTranscription end result=\(result.debugDescription)")
+        debugLog("stopStreamingTranscription end resultLength=\(result.count)")
         return result
     }
 
@@ -547,6 +547,20 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
             audioStreamTranscriber = nil
         }
         deactivateAudioSessionAfterStreaming()
+    }
+
+    func emitStreamingRecognitionEvent(
+        _ text: String,
+        isFinal: Bool,
+        onEvent: SpeechRecognitionStreamingEventHandler
+    ) {
+        if isFinal {
+            guard !hasEmittedFinalTranscription else { return }
+            hasEmittedFinalTranscription = true
+            onEvent(.finalTranscription(text))
+        } else {
+            onEvent(.partialTranscription(text))
+        }
     }
 
     func handleStreamingFailure(
@@ -597,7 +611,7 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
         continuation.resume(returning: text)
     }
 
-    private func emitFinalTranscriptionIfNeeded(_ text: String) {
+    func emitFinalTranscriptionIfNeeded(_ text: String) {
         guard !hasEmittedFinalTranscription else { return }
         hasEmittedFinalTranscription = true
         eventHandler?(.finalTranscription(text))

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -230,15 +230,11 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
         initializationTask = nil
         startupTask?.cancel()
         startupTask = nil
-        streamTranscriptionTask?.cancel()
-        streamTranscriptionTask = nil
+        completePendingFinalTranscriptionWithCurrentText()
+        finishStreamingSession(clearLastTranscribedText: true, resetTranscriber: true)
         whisperKit = nil
         isInitializing = false
         currentModelVariant = nil
-        audioStreamTranscriber = nil
-        finalTranscriptionContinuation?.resume(returning: currentTranscript)
-        finalTranscriptionContinuation = nil
-        isStreaming = false
         lastError = nil
         loadingState = .idle
     }
@@ -338,9 +334,14 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
     }
 
     public func startStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws {
-        try await startStreamingTranscription { text, isFinal in
-            onEvent(isFinal ? .finalTranscription(text) : .partialTranscription(text))
-        }
+        try await startStreamingTranscription(
+            onPartialResult: { text, isFinal in
+                onEvent(isFinal ? .finalTranscription(text) : .partialTranscription(text))
+            },
+            onError: { error in
+                onEvent(.recognitionFailed(error.localizedDescription))
+            }
+        )
     }
 
     public func stopStreamingRecognition() async -> String? {
@@ -349,32 +350,40 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
 
     @discardableResult
     public func runStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws -> String? {
-        try await prepareStreamingTranscriber { text, isFinal in
-            onEvent(isFinal ? .finalTranscription(text) : .partialTranscription(text))
-        }
+        try await withTaskCancellationHandler {
+            try await prepareStreamingTranscriber { text, isFinal in
+                onEvent(isFinal ? .finalTranscription(text) : .partialTranscription(text))
+            }
 
-        hasEmittedFinalTranscription = false
-        isStreaming = true
-        debugLog("running AudioStreamTranscriber until stopped")
-        do {
-            try await audioStreamTranscriber?.startStreamTranscription()
-            isStreaming = false
-            return currentTranscript.isEmpty ? nil : currentTranscript
-        } catch is CancellationError {
-            isStreaming = false
-            throw CancellationError()
-        } catch {
-            isStreaming = false
-            let speechError = error as? WhisperKitLangToolsSpeechError ?? .transcriptionFailed(error.localizedDescription)
-            lastError = speechError
-            eventHandler?(.recognitionFailed(speechError.localizedDescription))
-            debugLog("AudioStreamTranscriber run threw: \(speechError.localizedDescription)")
-            throw speechError
+            hasEmittedFinalTranscription = false
+            isStreaming = true
+            debugLog("running AudioStreamTranscriber until stopped")
+            do {
+                try await audioStreamTranscriber?.startStreamTranscription()
+                finishStreamingSession(clearLastTranscribedText: false, resetTranscriber: false)
+                return currentTranscript.isEmpty ? nil : currentTranscript
+            } catch is CancellationError {
+                await stopStreamingCapture(clearLastTranscribedText: false, resetTranscriber: false)
+                throw CancellationError()
+            } catch {
+                await stopStreamingCapture(clearLastTranscribedText: false, resetTranscriber: false)
+                let speechError = error as? WhisperKitLangToolsSpeechError ?? .transcriptionFailed(error.localizedDescription)
+                handleStreamingFailure(speechError, onError: { error in
+                    onEvent(.recognitionFailed(error.localizedDescription))
+                })
+                debugLog("AudioStreamTranscriber run threw: \(speechError.localizedDescription)")
+                throw speechError
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                await self?.stopStreamingCapture(clearLastTranscribedText: false, resetTranscriber: false)
+            }
         }
     }
 
     public func startStreamingTranscription(
-        onPartialResult: @escaping (String, Bool) -> Void
+        onPartialResult: @escaping (String, Bool) -> Void,
+        onError: (@MainActor @Sendable (WhisperKitLangToolsSpeechError) -> Void)? = nil
     ) async throws {
         try await prepareStreamingTranscriber(onPartialResult: onPartialResult)
 
@@ -393,15 +402,14 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
                 }
             } catch is CancellationError {
                 await MainActor.run { [weak self] in
-                    self?.isStreaming = false
+                    self?.finishStreamingSession(clearLastTranscribedText: false, resetTranscriber: false, cancelTask: false)
                 }
             } catch {
                 await MainActor.run { [weak self] in
                     guard let self else { return }
-                    self.isStreaming = false
+                    self.finishStreamingSession(clearLastTranscribedText: false, resetTranscriber: false, cancelTask: false)
                     let speechError = error as? WhisperKitLangToolsSpeechError ?? .transcriptionFailed(error.localizedDescription)
-                    self.lastError = speechError
-                    self.eventHandler?(.recognitionFailed(speechError.localizedDescription))
+                    self.handleStreamingFailure(speechError, onError: onError)
                     self.debugLog("AudioStreamTranscriber start threw: \(speechError.localizedDescription)")
                 }
             }
@@ -487,13 +495,50 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
                 self.completeFinalTranscription(self.lastTranscribedText)
             }
         }
-        streamTranscriptionTask?.cancel()
-        streamTranscriptionTask = nil
-        isStreaming = false
-        lastTranscribedText = ""
-        deactivateAudioSessionAfterStreaming()
+        finishStreamingSession(clearLastTranscribedText: true, resetTranscriber: false)
         debugLog("stopStreamingTranscription end result=\(result.debugDescription)")
         return result
+    }
+
+    private func stopStreamingCapture(clearLastTranscribedText: Bool, resetTranscriber: Bool) async {
+        let transcriber = audioStreamTranscriber
+        await transcriber?.stopStreamTranscription()
+        completePendingFinalTranscriptionWithCurrentText()
+        finishStreamingSession(clearLastTranscribedText: clearLastTranscribedText, resetTranscriber: resetTranscriber)
+    }
+
+    private func finishStreamingSession(
+        clearLastTranscribedText: Bool,
+        resetTranscriber: Bool,
+        cancelTask: Bool = true
+    ) {
+        if cancelTask {
+            streamTranscriptionTask?.cancel()
+        }
+        streamTranscriptionTask = nil
+        isStreaming = false
+        if clearLastTranscribedText {
+            lastTranscribedText = ""
+        }
+        if resetTranscriber {
+            audioStreamTranscriber = nil
+        }
+        deactivateAudioSessionAfterStreaming()
+    }
+
+    func handleStreamingFailure(
+        _ speechError: WhisperKitLangToolsSpeechError,
+        onError: (@MainActor @Sendable (WhisperKitLangToolsSpeechError) -> Void)?
+    ) {
+        lastError = speechError
+        eventHandler?(.recognitionFailed(speechError.localizedDescription))
+        onError?(speechError)
+    }
+
+    private func completePendingFinalTranscriptionWithCurrentText() {
+        guard let continuation = finalTranscriptionContinuation else { return }
+        finalTranscriptionContinuation = nil
+        continuation.resume(returning: currentTranscript.isEmpty ? lastTranscribedText : currentTranscript)
     }
 
     private func normalizedWhisperLanguageIdentifier() -> String? {

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -64,8 +64,9 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
     private var initializationTask: Task<Void, Never>?
     private var streamTranscriptionTask: Task<Void, Never>?
     private var finalTranscriptionContinuation: CheckedContinuation<String, Never>?
-    private var lastTranscribedText = ""
+    var lastTranscribedText = ""
     private var hasEmittedFinalTranscription = false
+    private var isStoppingStreaming = false
 
     public init(
         modelVariant: String = "base",
@@ -235,6 +236,7 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
         whisperKit = nil
         isInitializing = false
         currentModelVariant = nil
+        isStoppingStreaming = false
         lastError = nil
         loadingState = .idle
     }
@@ -355,7 +357,7 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
                 onEvent(isFinal ? .finalTranscription(text) : .partialTranscription(text))
             }
 
-            hasEmittedFinalTranscription = false
+            resetStreamingTranscriptState()
             isStreaming = true
             debugLog("running AudioStreamTranscriber until stopped")
             do {
@@ -387,7 +389,7 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
     ) async throws {
         try await prepareStreamingTranscriber(onPartialResult: onPartialResult)
 
-        hasEmittedFinalTranscription = false
+        resetStreamingTranscriptState()
         isStreaming = true
         debugLog("starting AudioStreamTranscriber")
         let transcriber = audioStreamTranscriber
@@ -501,10 +503,24 @@ public final class WhisperKitSpeechRecognitionProvider: BlockingStreamingSpeechR
     }
 
     private func stopStreamingCapture(clearLastTranscribedText: Bool, resetTranscriber: Bool) async {
+        guard !isStoppingStreaming else { return }
+        isStoppingStreaming = true
+        defer { isStoppingStreaming = false }
         let transcriber = audioStreamTranscriber
         await transcriber?.stopStreamTranscription()
         completePendingFinalTranscriptionWithCurrentText()
         finishStreamingSession(clearLastTranscribedText: clearLastTranscribedText, resetTranscriber: resetTranscriber)
+    }
+
+    func setStreamingTranscriptForTesting(_ text: String) {
+        currentTranscript = text
+        lastTranscribedText = text
+    }
+
+    func resetStreamingTranscriptState() {
+        currentTranscript = ""
+        lastTranscribedText = ""
+        hasEmittedFinalTranscription = false
     }
 
     private func finishStreamingSession(

--- a/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
+++ b/Sources/WhisperKit/WhisperKitSpeechRecognitionProvider.swift
@@ -3,6 +3,7 @@ import LangTools
 
 #if canImport(WhisperKit) && canImport(AVFoundation) && !os(watchOS)
 import AVFoundation
+import CoreML
 import WhisperKit
 
 /// WhisperKit loading state for provider UIs.
@@ -61,6 +62,7 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
     private var audioStreamTranscriber: AudioStreamTranscriber?
     private var startupTask: Task<Void, Never>?
     private var initializationTask: Task<Void, Never>?
+    private var streamTranscriptionTask: Task<Void, Never>?
     private var finalTranscriptionContinuation: CheckedContinuation<String, Never>?
     private var lastTranscribedText = ""
     private var hasEmittedFinalTranscription = false
@@ -128,16 +130,8 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
         startupTask = Task { [weak self] in
             guard let self else { return }
             do {
-                try await self.startStreamingTranscription { [weak self] text, isFinal in
-                    Task { @MainActor [weak self] in
-                        guard let self else { return }
-                        self.currentTranscript = text
-                        if isFinal {
-                            self.emitFinalTranscriptionIfNeeded(text)
-                        } else {
-                            self.eventHandler?(.partialTranscription(text))
-                        }
-                    }
+                try await self.startStreamingRecognition { [weak self] event in
+                    self?.eventHandler?(event)
                 }
             } catch is CancellationError {
                 self.isStreaming = false
@@ -236,6 +230,8 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
         initializationTask = nil
         startupTask?.cancel()
         startupTask = nil
+        streamTranscriptionTask?.cancel()
+        streamTranscriptionTask = nil
         whisperKit = nil
         isInitializing = false
         currentModelVariant = nil
@@ -293,7 +289,7 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
 
         loadingState = isModelDownloaded(modelVariant) ? .loading : .downloading
         do {
-            let config = WhisperKitConfig(model: modelVariant, verbose: false, prewarm: false, load: false, download: true)
+            let config = makeWhisperKitConfig(modelVariant: modelVariant)
             let initializedWhisperKit = try await WhisperKit(config)
             try Task.checkCancellation()
             whisperKit = initializedWhisperKit
@@ -313,6 +309,21 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
             loadingState = .failed(error.localizedDescription)
             throw WhisperKitLangToolsSpeechError.transcriptionFailed("WhisperKit initialization failed: \(error.localizedDescription)")
         }
+    }
+
+    private func makeWhisperKitConfig(modelVariant: String) -> WhisperKitConfig {
+        let computeOptions = ModelComputeOptions(
+            audioEncoderCompute: .cpuAndGPU,
+            textDecoderCompute: .cpuAndNeuralEngine
+        )
+        return WhisperKitConfig(
+            model: modelVariant,
+            computeOptions: computeOptions,
+            verbose: false,
+            prewarm: false,
+            load: false,
+            download: true
+        )
     }
 
     func stripSpecialTokens(_ text: String) -> String {
@@ -337,6 +348,41 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
     }
 
     public func startStreamingTranscription(
+        onPartialResult: @escaping (String, Bool) -> Void
+    ) async throws {
+        try await prepareStreamingTranscriber(onPartialResult: onPartialResult)
+
+        hasEmittedFinalTranscription = false
+        isStreaming = true
+        debugLog("starting AudioStreamTranscriber")
+        let transcriber = audioStreamTranscriber
+        streamTranscriptionTask?.cancel()
+        streamTranscriptionTask = Task { [weak self, transcriber] in
+            do {
+                try await transcriber?.startStreamTranscription()
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    self.debugLog("AudioStreamTranscriber start returned")
+                    self.isStreaming = false
+                }
+            } catch is CancellationError {
+                await MainActor.run { [weak self] in
+                    self?.isStreaming = false
+                }
+            } catch {
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    self.isStreaming = false
+                    let speechError = error as? WhisperKitLangToolsSpeechError ?? .transcriptionFailed(error.localizedDescription)
+                    self.lastError = speechError
+                    self.eventHandler?(.recognitionFailed(speechError.localizedDescription))
+                    self.debugLog("AudioStreamTranscriber start threw: \(speechError.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    private func prepareStreamingTranscriber(
         onPartialResult: @escaping (String, Bool) -> Void
     ) async throws {
         debugLog("startStreamingTranscription begin state=\(loadingState.description) modelState=\(modelState) available=\(isAvailable) language=\(configuredLanguageIdentifier ?? "auto") normalizedLanguage=\(normalizedWhisperLanguageIdentifier() ?? "auto")")
@@ -381,7 +427,10 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
                 let confirmedText = newState.confirmedSegments.map { self.stripSpecialTokens($0.text) }.joined(separator: " ")
                 let unconfirmedText = newState.unconfirmedSegments.map { self.stripSpecialTokens($0.text) }.joined(separator: " ")
                 let fullText = (confirmedText + " " + unconfirmedText).trimmingCharacters(in: .whitespacesAndNewlines)
-                if !fullText.isEmpty { self.lastTranscribedText = fullText }
+                if !fullText.isEmpty {
+                    self.lastTranscribedText = fullText
+                    self.currentTranscript = fullText
+                }
                 let isFinal = !newState.isRecording && oldState.isRecording
                 let oldFullText = (oldState.confirmedSegments.map { self.stripSpecialTokens($0.text) } + oldState.unconfirmedSegments.map { self.stripSpecialTokens($0.text) }).joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
                 if oldState.isRecording != newState.isRecording || oldState.confirmedSegments.count != newState.confirmedSegments.count || oldState.unconfirmedSegments.count != newState.unconfirmedSegments.count || isFinal {
@@ -397,20 +446,6 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
             }
         }
 
-        hasEmittedFinalTranscription = false
-        isStreaming = true
-        debugLog("starting AudioStreamTranscriber")
-        do {
-            try await audioStreamTranscriber?.startStreamTranscription()
-            debugLog("AudioStreamTranscriber start returned")
-        } catch {
-            isStreaming = false
-            let speechError = error as? WhisperKitLangToolsSpeechError ?? .transcriptionFailed(error.localizedDescription)
-            lastError = speechError
-            eventHandler?(.recognitionFailed(speechError.localizedDescription))
-            debugLog("AudioStreamTranscriber start threw: \(speechError.localizedDescription)")
-            throw speechError
-        }
     }
 
     public func stopStreamingTranscription() async -> String {
@@ -426,6 +461,8 @@ public final class WhisperKitSpeechRecognitionProvider: StreamingSpeechRecogniti
                 self.completeFinalTranscription(self.lastTranscribedText)
             }
         }
+        streamTranscriptionTask?.cancel()
+        streamTranscriptionTask = nil
         isStreaming = false
         lastTranscribedText = ""
         deactivateAudioSessionAfterStreaming()

--- a/Tests/AppleSpeechTests/AppleSpeechTests.swift
+++ b/Tests/AppleSpeechTests/AppleSpeechTests.swift
@@ -21,6 +21,28 @@ final class AppleSpeechTests: XCTestCase {
         XCTAssertEqual(provider.currentTranscript, "")
     }
 
+    @MainActor
+    func testStreamingFailureEmitsEventAndThrowsBlockingContinuation() async {
+        let provider = AppleSpeechRecognitionProvider(locale: Locale(identifier: "en-US"))
+        let expectedError = NSError(domain: "AppleSpeechTests", code: 42, userInfo: [NSLocalizedDescriptionKey: "recognition failed"])
+        var failedMessage: String?
+        provider.eventHandler = { event in
+            if case .recognitionFailed(let message) = event {
+                failedMessage = message
+            }
+        }
+
+        do {
+            _ = try await provider.test_failStreamingForTesting(expectedError)
+            XCTFail("Expected blocking streaming continuation to throw")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, expectedError.domain)
+            XCTAssertEqual((error as NSError).code, expectedError.code)
+            XCTAssertEqual(failedMessage, "recognition failed")
+            XCTAssertFalse(provider.isStreaming)
+        }
+    }
+
     // MARK: - Locale Support Tests
 
     func testSupportedLocalesNotEmpty() {

--- a/Tests/AppleSpeechTests/AppleSpeechTests.swift
+++ b/Tests/AppleSpeechTests/AppleSpeechTests.swift
@@ -43,6 +43,25 @@ final class AppleSpeechTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testStreamingFailureEmitsSessionFailureCallback() async {
+        let provider = AppleSpeechRecognitionProvider(locale: Locale(identifier: "en-US"))
+        let expectedError = NSError(domain: "AppleSpeechTests", code: 42, userInfo: [NSLocalizedDescriptionKey: "recognition failed"])
+        var failedMessage: String?
+
+        do {
+            _ = try await provider.test_failStreamingForTesting(expectedError) { error in
+                failedMessage = error.localizedDescription
+            }
+            XCTFail("Expected blocking streaming continuation to throw")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, expectedError.domain)
+            XCTAssertEqual((error as NSError).code, expectedError.code)
+            XCTAssertEqual(failedMessage, "recognition failed")
+            XCTAssertFalse(provider.isStreaming)
+        }
+    }
+
     // MARK: - Locale Support Tests
 
     func testSupportedLocalesNotEmpty() {

--- a/Tests/AppleSpeechTests/AppleSpeechTests.swift
+++ b/Tests/AppleSpeechTests/AppleSpeechTests.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 import Speech
+import LangTools
 @testable import AppleLangTools
 
 final class AppleSpeechTests: XCTestCase {
@@ -22,23 +23,23 @@ final class AppleSpeechTests: XCTestCase {
     }
 
     @MainActor
-    func testStreamingFailureEmitsEventAndThrowsBlockingContinuation() async {
+    func testStreamingFailureUsesSessionCallbackWithoutDuplicateEventHandlerDelivery() async {
         let provider = AppleSpeechRecognitionProvider(locale: Locale(identifier: "en-US"))
         let expectedError = NSError(domain: "AppleSpeechTests", code: 42, userInfo: [NSLocalizedDescriptionKey: "recognition failed"])
-        var failedMessage: String?
+        var events: [SpeechRecognitionEvent] = []
         provider.eventHandler = { event in
-            if case .recognitionFailed(let message) = event {
-                failedMessage = message
-            }
+            events.append(event)
         }
 
         do {
-            _ = try await provider.test_failStreamingForTesting(expectedError)
+            _ = try await provider.test_failStreamingForTesting(expectedError) { error in
+                events.append(.recognitionFailed(error.localizedDescription))
+            }
             XCTFail("Expected blocking streaming continuation to throw")
         } catch {
             XCTAssertEqual((error as NSError).domain, expectedError.domain)
             XCTAssertEqual((error as NSError).code, expectedError.code)
-            XCTAssertEqual(failedMessage, "recognition failed")
+            XCTAssertEqual(events, [.recognitionFailed("recognition failed")])
             XCTAssertFalse(provider.isStreaming)
         }
     }
@@ -60,6 +61,25 @@ final class AppleSpeechTests: XCTestCase {
             XCTAssertEqual(failedMessage, "recognition failed")
             XCTAssertFalse(provider.isStreaming)
         }
+    }
+
+    @MainActor
+    func testBlockingStreamingRejectsOverlappingSession() async {
+        let provider = AppleSpeechRecognitionProvider(locale: Locale(identifier: "en-US"))
+        let firstRun = Task { @MainActor in
+            try await provider.test_runBlockedStreamingForTesting()
+        }
+        await Task.yield()
+
+        do {
+            _ = try await provider.test_runBlockedStreamingForTesting()
+            XCTFail("Expected overlapping blocking streaming session to throw")
+        } catch {
+            XCTAssertEqual(error.localizedDescription, "Recording failed: Streaming recognition is already active")
+        }
+
+        firstRun.cancel()
+        _ = await firstRun.result
     }
 
     // MARK: - Locale Support Tests

--- a/Tests/AppleSpeechTests/AppleSpeechTests.swift
+++ b/Tests/AppleSpeechTests/AppleSpeechTests.swift
@@ -11,6 +11,16 @@ import Speech
 
 final class AppleSpeechTests: XCTestCase {
 
+    @MainActor
+    func testResetStreamingTranscriptStateClearsPriorSessionText() {
+        let provider = AppleSpeechRecognitionProvider(locale: Locale(identifier: "en-US"))
+
+        provider.setStreamingTranscriptForTesting("previous session")
+        provider.resetStreamingTranscriptState()
+
+        XCTAssertEqual(provider.currentTranscript, "")
+    }
+
     // MARK: - Locale Support Tests
 
     func testSupportedLocalesNotEmpty() {

--- a/Tests/LangToolsTests/ProviderAbstractionsTests.swift
+++ b/Tests/LangToolsTests/ProviderAbstractionsTests.swift
@@ -225,7 +225,7 @@ final class ProviderAbstractionsTests: XCTestCase {
     }
 
     @MainActor
-    func testStreamingSpeechRecognitionProviderOverrideRunsUntilStopped() async throws {
+    func testStreamingSpeechRecognitionProviderUsesProviderOverride() async throws {
         final class StubBlockingStreamingProvider: StreamingSpeechRecognitionProviding {
             let providerID = LangToolsProviderID(rawValue: "stub.blocking")
             let displayName = "Stub Blocking"

--- a/Tests/LangToolsTests/ProviderAbstractionsTests.swift
+++ b/Tests/LangToolsTests/ProviderAbstractionsTests.swift
@@ -225,6 +225,65 @@ final class ProviderAbstractionsTests: XCTestCase {
     }
 
     @MainActor
+    func testBlockingStreamingSpeechRecognitionProviderRunsUntilStopped() async throws {
+        final class StubBlockingStreamingProvider: BlockingStreamingSpeechRecognitionProviding {
+            let providerID = LangToolsProviderID(rawValue: "stub.blocking")
+            let displayName = "Stub Blocking"
+            let capabilities = ProviderCapabilities(runsOnDevice: true, supportsStreamingPartials: true)
+            let authorizationState: ProviderAuthorizationState = .authorized
+            let assetState: ProviderAssetState = .notRequired
+            let isAvailable = true
+            private(set) var isListening = false
+            var isStreaming: Bool { isListening }
+            var currentTranscript = ""
+            var eventHandler: (@MainActor @Sendable (SpeechRecognitionEvent) -> Void)?
+
+            func configure(languageIdentifier: String) {}
+            func requestAuthorization() async -> ProviderAuthorizationState { .authorized }
+            func refreshAuthorizationState() {}
+            func prepareAssetsIfNeeded() {}
+            func startRecognition() throws {}
+            func stopRecognition(finalizePending: Bool, clearTranscript: Bool) {}
+            func finalizeRecognition() {}
+
+            func transcribe(audioData: Data) async throws -> any LangToolsTranscriptionResponse {
+                "blocking"
+            }
+
+            func startStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws {
+                isListening = true
+                currentTranscript = "hello"
+                onEvent(.partialTranscription("hel"))
+            }
+
+            func stopStreamingRecognition() async -> String? {
+                isListening = false
+                return currentTranscript
+            }
+
+            @discardableResult
+            func runStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws -> String? {
+                isListening = true
+                onEvent(.partialTranscription("hel"))
+                currentTranscript = "hello"
+                onEvent(.finalTranscription("hello"))
+                isListening = false
+                return currentTranscript
+            }
+        }
+
+        let provider: any BlockingStreamingSpeechRecognitionProviding = StubBlockingStreamingProvider()
+        var events: [SpeechRecognitionEvent] = []
+        let finalText = try await provider.runStreamingRecognition { event in
+            events.append(event)
+        }
+
+        XCTAssertEqual(events, [.partialTranscription("hel"), .finalTranscription("hello")])
+        XCTAssertEqual(finalText, "hello")
+        XCTAssertFalse(provider.isStreaming)
+    }
+
+    @MainActor
     func testStreamingProviderDefaultRejectsExternalAudio() async throws {
         final class NativeOnlyStreamingProvider: StreamingSpeechRecognitionProviding {
             let providerID = LangToolsProviderID(rawValue: "stub.native")

--- a/Tests/LangToolsTests/ProviderAbstractionsTests.swift
+++ b/Tests/LangToolsTests/ProviderAbstractionsTests.swift
@@ -225,8 +225,8 @@ final class ProviderAbstractionsTests: XCTestCase {
     }
 
     @MainActor
-    func testBlockingStreamingSpeechRecognitionProviderRunsUntilStopped() async throws {
-        final class StubBlockingStreamingProvider: BlockingStreamingSpeechRecognitionProviding {
+    func testStreamingSpeechRecognitionProviderOverrideRunsUntilStopped() async throws {
+        final class StubBlockingStreamingProvider: StreamingSpeechRecognitionProviding {
             let providerID = LangToolsProviderID(rawValue: "stub.blocking")
             let displayName = "Stub Blocking"
             let capabilities = ProviderCapabilities(runsOnDevice: true, supportsStreamingPartials: true)
@@ -272,7 +272,57 @@ final class ProviderAbstractionsTests: XCTestCase {
             }
         }
 
-        let provider: any BlockingStreamingSpeechRecognitionProviding = StubBlockingStreamingProvider()
+        let provider: any StreamingSpeechRecognitionProviding = StubBlockingStreamingProvider()
+        var events: [SpeechRecognitionEvent] = []
+        let finalText = try await provider.runStreamingRecognition { event in
+            events.append(event)
+        }
+
+        XCTAssertEqual(events, [.partialTranscription("hel"), .finalTranscription("hello")])
+        XCTAssertEqual(finalText, "hello")
+        XCTAssertFalse(provider.isStreaming)
+    }
+
+    @MainActor
+    func testStreamingSpeechRecognitionProviderDefaultRunCompletesOnFinalEvent() async throws {
+        final class DefaultRunStreamingProvider: StreamingSpeechRecognitionProviding {
+            let providerID = LangToolsProviderID(rawValue: "stub.default-run")
+            let displayName = "Stub Default Run"
+            let capabilities = ProviderCapabilities(runsOnDevice: true, supportsStreamingPartials: true)
+            let authorizationState: ProviderAuthorizationState = .authorized
+            let assetState: ProviderAssetState = .notRequired
+            let isAvailable = true
+            private(set) var isListening = false
+            var isStreaming: Bool { isListening }
+            var currentTranscript = ""
+            var eventHandler: (@MainActor @Sendable (SpeechRecognitionEvent) -> Void)?
+
+            func configure(languageIdentifier: String) {}
+            func requestAuthorization() async -> ProviderAuthorizationState { .authorized }
+            func refreshAuthorizationState() {}
+            func prepareAssetsIfNeeded() {}
+            func startRecognition() throws {}
+            func stopRecognition(finalizePending: Bool, clearTranscript: Bool) {}
+            func finalizeRecognition() {}
+
+            func transcribe(audioData: Data) async throws -> any LangToolsTranscriptionResponse {
+                "default"
+            }
+
+            func startStreamingRecognition(onEvent: @escaping SpeechRecognitionStreamingEventHandler) async throws {
+                isListening = true
+                onEvent(.partialTranscription("hel"))
+                currentTranscript = "hello"
+                onEvent(.finalTranscription("hello"))
+            }
+
+            func stopStreamingRecognition() async -> String? {
+                isListening = false
+                return currentTranscript
+            }
+        }
+
+        let provider: any StreamingSpeechRecognitionProviding = DefaultRunStreamingProvider()
         var events: [SpeechRecognitionEvent] = []
         let finalText = try await provider.runStreamingRecognition { event in
             events.append(event)

--- a/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
+++ b/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
@@ -53,6 +53,17 @@ final class WhisperKitSpeechRecognitionProviderTests: XCTestCase {
     }
 
     @MainActor
+    func testResetStreamingTranscriptStateClearsPriorSessionText() {
+        let provider = WhisperKitSpeechRecognitionProvider()
+
+        provider.setStreamingTranscriptForTesting("previous session")
+        provider.resetStreamingTranscriptState()
+
+        XCTAssertEqual(provider.currentTranscript, "")
+        XCTAssertEqual(provider.lastTranscribedText, "")
+    }
+
+    @MainActor
     func testStreamingFailureRoutesToSessionCallbackAndEventHandler() {
         let provider = WhisperKitSpeechRecognitionProvider()
         let error = WhisperKitLangToolsSpeechError.transcriptionFailed("boom")

--- a/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
+++ b/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
@@ -64,22 +64,20 @@ final class WhisperKitSpeechRecognitionProviderTests: XCTestCase {
     }
 
     @MainActor
-    func testStreamingFailureRoutesToSessionCallbackAndEventHandler() {
+    func testStreamingFailureRoutesToSingleSessionCallback() {
         let provider = WhisperKitSpeechRecognitionProvider()
         let error = WhisperKitLangToolsSpeechError.transcriptionFailed("boom")
-        var eventHandlerEvents: [SpeechRecognitionEvent] = []
-        var sessionEvents: [SpeechRecognitionEvent] = []
+        var events: [SpeechRecognitionEvent] = []
         provider.eventHandler = { event in
-            eventHandlerEvents.append(event)
+            events.append(event)
         }
 
         provider.handleStreamingFailure(error, onError: { error in
-            sessionEvents.append(.recognitionFailed(error.localizedDescription))
+            provider.eventHandler?(.recognitionFailed(error.localizedDescription))
         })
 
         XCTAssertEqual(provider.lastError?.localizedDescription, error.localizedDescription)
-        XCTAssertEqual(eventHandlerEvents, [.recognitionFailed(error.localizedDescription)])
-        XCTAssertEqual(sessionEvents, [.recognitionFailed(error.localizedDescription)])
+        XCTAssertEqual(events, [.recognitionFailed(error.localizedDescription)])
     }
 
     @MainActor

--- a/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
+++ b/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
@@ -81,6 +81,25 @@ final class WhisperKitSpeechRecognitionProviderTests: XCTestCase {
     }
 
     @MainActor
+    func testStreamingFinalEventIsDeduplicated() {
+        let provider = WhisperKitSpeechRecognitionProvider()
+        var events: [SpeechRecognitionEvent] = []
+
+        provider.emitStreamingRecognitionEvent("hello", isFinal: true) { event in
+            events.append(event)
+        }
+        provider.emitStreamingRecognitionEvent("hello", isFinal: true) { event in
+            events.append(event)
+        }
+        provider.eventHandler = { event in
+            events.append(event)
+        }
+        provider.emitFinalTranscriptionIfNeeded("hello")
+
+        XCTAssertEqual(events, [.finalTranscription("hello")])
+    }
+
+    @MainActor
     func testResetClearsLazyStreamingState() {
         let provider = WhisperKitSpeechRecognitionProvider()
 

--- a/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
+++ b/Tests/WhisperKitLangToolsTests/WhisperKitSpeechRecognitionProviderTests.swift
@@ -51,5 +51,38 @@ final class WhisperKitSpeechRecognitionProviderTests: XCTestCase {
             "Hello there friend"
         )
     }
+
+    @MainActor
+    func testStreamingFailureRoutesToSessionCallbackAndEventHandler() {
+        let provider = WhisperKitSpeechRecognitionProvider()
+        let error = WhisperKitLangToolsSpeechError.transcriptionFailed("boom")
+        var eventHandlerEvents: [SpeechRecognitionEvent] = []
+        var sessionEvents: [SpeechRecognitionEvent] = []
+        provider.eventHandler = { event in
+            eventHandlerEvents.append(event)
+        }
+
+        provider.handleStreamingFailure(error, onError: { error in
+            sessionEvents.append(.recognitionFailed(error.localizedDescription))
+        })
+
+        XCTAssertEqual(provider.lastError?.localizedDescription, error.localizedDescription)
+        XCTAssertEqual(eventHandlerEvents, [.recognitionFailed(error.localizedDescription)])
+        XCTAssertEqual(sessionEvents, [.recognitionFailed(error.localizedDescription)])
+    }
+
+    @MainActor
+    func testResetClearsLazyStreamingState() {
+        let provider = WhisperKitSpeechRecognitionProvider()
+
+        XCTAssertNoThrow(try provider.startRecognition())
+        XCTAssertTrue(provider.isStreaming)
+
+        provider.reset()
+
+        XCTAssertFalse(provider.isStreaming)
+        XCTAssertEqual(provider.loadingState, .idle)
+        XCTAssertNil(provider.lastError)
+    }
 }
 #endif


### PR DESCRIPTION
## Summary

Standardizes LangTools provider-owned streaming startup semantics across Apple Speech and WhisperKit while preserving an optional structured-concurrency/blocking streaming API for callers that want the async call to span the session lifetime.

Apple Speech already starts capture and returns while events continue asynchronously. WhisperKit previously awaited `AudioStreamTranscriber.startStreamTranscription()`, which does not return until streaming stops. This made both providers conform to the same protocol but behave differently for callers.

This PR updates WhisperKit so `startStreamingRecognition(...)` prepares the model/transcriber, starts the long-running `AudioStreamTranscriber` loop in an internal task, and returns after startup like Apple Speech.

## Changes

- Clarifies `StreamingSpeechRecognitionProviding.startStreamingRecognition(...)` docs: provider-owned streaming should return after capture startup, with events delivered asynchronously until stopped.
- Adds a WhisperKit internal stream task for the long-running transcriber loop.
- Keeps `currentTranscript` synchronized from WhisperKit streaming callbacks.
- Cancels/cleans the internal WhisperKit stream task during reset/stop.
- Routes asynchronous WhisperKit streaming failures through a single per-session error callback so primary `startRecognition()` callers do not receive duplicate `.recognitionFailed` events.
- Shares streaming cleanup across stop, reset, cancellation, and error paths so transcriber/audio-session state and pending final continuations do not leak after failures.
- Adds `BlockingStreamingSpeechRecognitionProviding` for callers that want to suspend until a streaming session ends:
  - `@discardableResult func runStreamingRecognition(...) async throws -> String?`
  - Apple Speech and WhisperKit conform.
  - The returned value is the best final transcript, but callers may ignore it and consume events only.
- Configures WhisperKit audio encoder compute to CPU/GPU while keeping text decoder on Neural Engine to avoid observed `AudioEncoder.mlmodelc` ANE load failures on-device.

## Validation

- `git -C external/LangTools.swift diff --check`
- `git diff --check`
- `cd external/LangTools.swift && swift test` — 246 passed after streaming failure cleanup
- Hermes integration checks from consuming repo:
  - `cd ios && swift test --filter ConversationViewModelTests`
  - `xcodebuild -project ios/HermesTranslate.xcodeproj -scheme HermesTranslate -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`

## Follow-up

- Smoke test Local Whisper streaming and failure handling on physical iOS hardware with `small` model.

## Latest review-fix validation

- `f4f473e` resets Apple Speech and WhisperKit streaming transcript state between sessions so reused providers cannot return stale text.
- WhisperKit streaming cancellation cleanup now guards against duplicate stop teardown.
- Added regression tests for Apple Speech and WhisperKit streaming transcript reset.
- Validation: `cd external/LangTools.swift && swift test` — 248 tests passed.
- Validation: `cd external/LangTools.swift && swift test --filter WhisperKitSpeechRecognitionProviderTests` — 8 tests passed after the final cleanup guard tweak.


Additional review fixes:

- Avoids double-completing Apple Speech blocking streaming continuations when startup fails before capture begins.
- Documents that WhisperKit `reset()` callers should stop active streaming before resetting provider state.


## Latest validation

- `7e6fd07` fixes Apple Speech blocking streaming startup-failure continuation completion and documents WhisperKit reset expectations.
- `swift test` — 248 tests passed.

## Latest Apple Speech error handling fix

- Routes mid-stream Apple Speech recognition task errors through the streaming failure path.
- Emits `.recognitionFailed` for Apple Speech mid-stream errors.
- Makes `runStreamingRecognition(...)` throw instead of completing successfully with `nil`/partial text when Apple Speech fails mid-stream.
- Adds regression coverage for failure event emission and thrown blocking continuation.

## Latest validation

- `swift test --filter AppleSpeechTests` — 18 tests passed.
- `swift test --filter WhisperKitSpeechRecognitionProviderTests` — passed.
- `swift test` — 249 tests passed.
- `git diff --check`



## Final WhisperKit review fix

- Removes duplicate `.recognitionFailed` delivery by making WhisperKit streaming failure handling fan out through one session callback.
- Updates the regression test to model `startRecognition()`-style callback aliasing and assert a single failure event.
- Resets WhisperKit streaming transcript state before transcriber preparation so stale text is not visible while a model prepares.
- Documents the `AudioEncoder.mlmodelc` ANE workaround inline near the WhisperKit compute options.

## Final validation

- `swift test --filter WhisperKitSpeechRecognitionProviderTests` — 8 tests passed.
- `swift test` — 249 tests passed.
- `git diff --check`



## Apple Speech session-event review fix

- Adds Apple Speech failure callback plumbing alongside partial/final callbacks.
- Forwards mid-stream Apple Speech failures through the caller-supplied `onEvent(.recognitionFailed(...))` for both `startStreamingRecognition(onEvent:)` and `runStreamingRecognition(onEvent:)`, so callers do not need to rely on the mutable provider `eventHandler`.
- Adds regression coverage for Apple Speech session failure callback delivery.

## Latest validation

- `swift test --filter AppleSpeechTests` — 19 tests passed.
- `swift test` — 250 tests passed.
- `git diff --check`

## Latest review-fix validation

- `8ce27ba` hardens Apple Speech streaming event routing so per-session callbacks do not duplicate `eventHandler` delivery and overlapping blocking streaming sessions are rejected instead of orphaning continuations.
- `7377593` deduplicates WhisperKit final streaming events across streaming callbacks and later finalization, and removes transcript text from WhisperKit debug logs in favor of lengths/counts.
- Added regression coverage for Apple duplicate failure delivery, Apple overlapping blocking sessions, and WhisperKit final-event dedupe.
- Validation: `swift test --filter AppleSpeechTests` — 20 tests passed.
- Validation: `swift test --filter WhisperKitSpeechRecognitionProviderTests` — 9 tests passed.
- Validation: `swift test` — 252 tests passed.

## Blocking streaming protocol cleanup

- `d0dc23b` removes the separate `BlockingStreamingSpeechRecognitionProviding` refinement protocol.
- `runStreamingRecognition(onEvent:)` is now a `StreamingSpeechRecognitionProviding` requirement with a default implementation built on `startStreamingRecognition(onEvent:)` / `stopStreamingRecognition()`.
- Apple Speech and WhisperKit keep provider-specific overrides, preserving dynamic dispatch through `any StreamingSpeechRecognitionProviding`.
- Added regression coverage for both the default blocking streaming path and provider override dispatch.

## Latest validation

- `swift test --filter LangToolsTests` — 98 tests passed.
- `swift test --filter AppleSpeechTests` — 20 tests passed.
- `swift test --filter WhisperKitSpeechRecognitionProviderTests` — 9 tests passed.
- `swift test --filter OpenAITests` — 65 tests passed.
- `swift test` — 253 tests passed.

## Latest WhisperKit cleanup fix

- `fb8237b` runs shared WhisperKit streaming cleanup when `AudioStreamTranscriber.startStreamTranscription()` returns normally from the non-blocking streaming task, deactivating the audio session and clearing the completed task reference.
- Narrows `lastTranscribedText` to `private(set)` while preserving test read access.
- Renames the provider override regression test to match its actual assertion.

## Latest validation

- `swift test --filter WhisperKitSpeechRecognitionProviderTests` — 9 tests passed.
- `swift test --filter LangToolsTests` — 98 tests passed.
- `swift test` — 253 tests passed.
- `git diff --check`
